### PR TITLE
fix: caip 2 todos

### DIFF
--- a/packages/automated-dispute/src/providers/protocolProvider.ts
+++ b/packages/automated-dispute/src/providers/protocolProvider.ts
@@ -251,19 +251,17 @@ export class ProtocolProvider implements IProtocolProvider {
         return true;
     }
 
-    // TODO: use Caip2 Chain ID instead of string in return type
     async getAvailableChains(): Promise<Caip2ChainId[]> {
         // TODO: implement actual method
         return ["eip155:1", "eip155:42161"];
     }
 
-    // TODO: waiting for ChainId to be merged for _chains parameter
     /**
      * Creates a request on the EBO Request Creator contract by simulating the transaction
      * and then executing it if the simulation is successful.
      *
      * @param {bigint} epoch - The epoch for which the request is being created.
-     * @param {string[]} chains - An array of chain identifiers where the request should be created.
+     * @param {Caip2ChainId[]} chains - An array of chain identifiers where the request should be created.
      * @throws {Error} Throws an error if the chains array is empty or if the transaction fails.
      * @throws {EBORequestCreator_InvalidEpoch} Throws if the epoch is invalid.
      * @throws {Oracle_InvalidRequestBody} Throws if the request body is invalid.
@@ -271,7 +269,7 @@ export class ProtocolProvider implements IProtocolProvider {
      * @throws {EBORequestCreator_ChainNotAdded} Throws if the specified chain is not added.
      * @returns {Promise<void>} A promise that resolves when the request is successfully created.
      */
-    async createRequest(epoch: bigint, chains: string[]): Promise<void> {
+    async createRequest(epoch: bigint, chains: Caip2ChainId[]): Promise<void> {
         if (chains.length === 0) {
             throw new Error("Chains array cannot be empty");
         }

--- a/packages/automated-dispute/src/services/eboActor.ts
+++ b/packages/automated-dispute/src/services/eboActor.ts
@@ -3,7 +3,7 @@ import { Caip2ChainId } from "@ebo-agent/blocknumber/dist/types.js";
 import { ILogger } from "@ebo-agent/shared";
 import { Mutex } from "async-mutex";
 import { Heap } from "heap-js";
-import { ContractFunctionRevertedError } from "viem";
+import { BlockNumber, ContractFunctionRevertedError } from "viem";
 
 import type {
     Dispute,
@@ -449,7 +449,7 @@ export class EboActor {
      * @param blockNumber block number to check proposals' status against
      * @returns an array of `Response` instances
      */
-    private activeProposals(blockNumber: bigint): Response[] {
+    private activeProposals(blockNumber: BlockNumber): Response[] {
         const responses = this.registry.getResponses();
 
         return responses.filter((response) => {
@@ -475,16 +475,6 @@ export class EboActor {
      * @param event `RequestCreated` event
      */
     private async onRequestCreated(event: EboEvent<"RequestCreated">): Promise<void> {
-        if (this.anyActiveProposal()) {
-            // Skipping new proposal until the actor receives a ResponseDisputed event;
-            // at that moment, it will be possible to re-propose again.
-            this.logger.info(
-                `There is an active proposal for request ${this.actorRequest.id}. Skipping...`,
-            );
-
-            return;
-        }
-
         const { chainId } = event.metadata;
 
         try {
@@ -503,16 +493,6 @@ export class EboActor {
                 throw err;
             }
         }
-    }
-
-    /**
-     * Check if there's at least one proposal that has not received any dispute yet.
-     *
-     * @returns
-     */
-    private anyActiveProposal() {
-        // TODO: implement this function
-        return false;
     }
 
     /**

--- a/packages/automated-dispute/src/services/eboActor.ts
+++ b/packages/automated-dispute/src/services/eboActor.ts
@@ -130,8 +130,6 @@ export class EboActor {
      * @throws {RequestMismatch} when an event from another request was enqueued in this actor
      */
     public processEvents(): Promise<void> {
-        // TODO: check for actor expiration (ie if it makes no sense to still handle the request events)
-
         return this.eventProcessingMutex.runExclusive(async () => {
             let event: EboEvent<EboEventName> | undefined;
 

--- a/packages/automated-dispute/src/types/prophet.ts
+++ b/packages/automated-dispute/src/types/prophet.ts
@@ -49,7 +49,7 @@ export interface Response {
 
         // To be byte-encode when sending it to Prophet
         response: {
-            chainId: Caip2ChainId; // TODO: Pending on-chain definition on CAIP-2 usage
+            chainId: Caip2ChainId;
             block: bigint;
             epoch: bigint;
         };


### PR DESCRIPTION
# 🤖 Linear

Part of GRT-178, closes GRT-179

## Description
* Remove already solved Caip2 related TODOs
* Remove `anyActiveProposal` method from `EboActor`. During the `RequestCreated` event handling, it should always try to propose a response (given that if the actor is handling this event, it is the most recent event thus it needs to be handled)