### PR TITLE
fix: prophet types

### DIFF
--- a/packages/automated-dispute/src/abis/bondEscalationModule.ts
+++ b/packages/automated-dispute/src/abis/bondEscalationModule.ts
@@ -1,1710 +1,515 @@
 export const bondEscalationModuleAbi = [
     {
-        abi: [
+        type: "constructor",
+        inputs: [{ name: "_oracle", type: "address", internalType: "contract IOracle" }],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "ORACLE",
+        inputs: [],
+        outputs: [{ name: "", type: "address", internalType: "contract IOracle" }],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "decodeRequestData",
+        inputs: [{ name: "_data", type: "bytes", internalType: "bytes" }],
+        outputs: [
             {
-                type: "constructor",
-                inputs: [{ name: "_oracle", type: "address", internalType: "contract IOracle" }],
-                stateMutability: "nonpayable",
-            },
-            {
-                type: "function",
-                name: "ORACLE",
-                inputs: [],
-                outputs: [{ name: "", type: "address", internalType: "contract IOracle" }],
-                stateMutability: "view",
-            },
-            {
-                type: "function",
-                name: "decodeRequestData",
-                inputs: [{ name: "_data", type: "bytes", internalType: "bytes" }],
-                outputs: [
+                name: "_params",
+                type: "tuple",
+                internalType: "struct IBondEscalationModule.RequestParameters",
+                components: [
                     {
-                        name: "_params",
-                        type: "tuple",
-                        internalType: "struct IBondEscalationModule.RequestParameters",
-                        components: [
-                            {
-                                name: "accountingExtension",
-                                type: "address",
-                                internalType: "contract IBondEscalationAccounting",
-                            },
-                            { name: "bondToken", type: "address", internalType: "contract IERC20" },
-                            { name: "bondSize", type: "uint256", internalType: "uint256" },
-                            {
-                                name: "maxNumberOfEscalations",
-                                type: "uint256",
-                                internalType: "uint256",
-                            },
-                            {
-                                name: "bondEscalationDeadline",
-                                type: "uint256",
-                                internalType: "uint256",
-                            },
-                            { name: "tyingBuffer", type: "uint256", internalType: "uint256" },
-                            { name: "disputeWindow", type: "uint256", internalType: "uint256" },
-                        ],
+                        name: "accountingExtension",
+                        type: "address",
+                        internalType: "contract IBondEscalationAccounting",
                     },
+                    { name: "bondToken", type: "address", internalType: "contract IERC20" },
+                    { name: "bondSize", type: "uint256", internalType: "uint256" },
+                    {
+                        name: "maxNumberOfEscalations",
+                        type: "uint256",
+                        internalType: "uint256",
+                    },
+                    {
+                        name: "bondEscalationDeadline",
+                        type: "uint256",
+                        internalType: "uint256",
+                    },
+                    { name: "tyingBuffer", type: "uint256", internalType: "uint256" },
+                    { name: "disputeWindow", type: "uint256", internalType: "uint256" },
                 ],
-                stateMutability: "pure",
             },
+        ],
+        stateMutability: "pure",
+    },
+    {
+        type: "function",
+        name: "disputeResponse",
+        inputs: [
             {
-                type: "function",
-                name: "disputeResponse",
-                inputs: [
-                    {
-                        name: "_request",
-                        type: "tuple",
-                        internalType: "struct IOracle.Request",
-                        components: [
-                            { name: "nonce", type: "uint96", internalType: "uint96" },
-                            { name: "requester", type: "address", internalType: "address" },
-                            { name: "requestModule", type: "address", internalType: "address" },
-                            { name: "responseModule", type: "address", internalType: "address" },
-                            { name: "disputeModule", type: "address", internalType: "address" },
-                            { name: "resolutionModule", type: "address", internalType: "address" },
-                            { name: "finalityModule", type: "address", internalType: "address" },
-                            { name: "requestModuleData", type: "bytes", internalType: "bytes" },
-                            { name: "responseModuleData", type: "bytes", internalType: "bytes" },
-                            { name: "disputeModuleData", type: "bytes", internalType: "bytes" },
-                            { name: "resolutionModuleData", type: "bytes", internalType: "bytes" },
-                            { name: "finalityModuleData", type: "bytes", internalType: "bytes" },
-                        ],
-                    },
-                    {
-                        name: "_response",
-                        type: "tuple",
-                        internalType: "struct IOracle.Response",
-                        components: [
-                            { name: "proposer", type: "address", internalType: "address" },
-                            { name: "requestId", type: "bytes32", internalType: "bytes32" },
-                            { name: "response", type: "bytes", internalType: "bytes" },
-                        ],
-                    },
-                    {
-                        name: "_dispute",
-                        type: "tuple",
-                        internalType: "struct IOracle.Dispute",
-                        components: [
-                            { name: "disputer", type: "address", internalType: "address" },
-                            { name: "proposer", type: "address", internalType: "address" },
-                            { name: "responseId", type: "bytes32", internalType: "bytes32" },
-                            { name: "requestId", type: "bytes32", internalType: "bytes32" },
-                        ],
-                    },
+                name: "_request",
+                type: "tuple",
+                internalType: "struct IOracle.Request",
+                components: [
+                    { name: "nonce", type: "uint96", internalType: "uint96" },
+                    { name: "requester", type: "address", internalType: "address" },
+                    { name: "requestModule", type: "address", internalType: "address" },
+                    { name: "responseModule", type: "address", internalType: "address" },
+                    { name: "disputeModule", type: "address", internalType: "address" },
+                    { name: "resolutionModule", type: "address", internalType: "address" },
+                    { name: "finalityModule", type: "address", internalType: "address" },
+                    { name: "requestModuleData", type: "bytes", internalType: "bytes" },
+                    { name: "responseModuleData", type: "bytes", internalType: "bytes" },
+                    { name: "disputeModuleData", type: "bytes", internalType: "bytes" },
+                    { name: "resolutionModuleData", type: "bytes", internalType: "bytes" },
+                    { name: "finalityModuleData", type: "bytes", internalType: "bytes" },
                 ],
-                outputs: [],
-                stateMutability: "nonpayable",
             },
             {
-                type: "function",
-                name: "finalizeRequest",
-                inputs: [
-                    {
-                        name: "_request",
-                        type: "tuple",
-                        internalType: "struct IOracle.Request",
-                        components: [
-                            { name: "nonce", type: "uint96", internalType: "uint96" },
-                            { name: "requester", type: "address", internalType: "address" },
-                            { name: "requestModule", type: "address", internalType: "address" },
-                            { name: "responseModule", type: "address", internalType: "address" },
-                            { name: "disputeModule", type: "address", internalType: "address" },
-                            { name: "resolutionModule", type: "address", internalType: "address" },
-                            { name: "finalityModule", type: "address", internalType: "address" },
-                            { name: "requestModuleData", type: "bytes", internalType: "bytes" },
-                            { name: "responseModuleData", type: "bytes", internalType: "bytes" },
-                            { name: "disputeModuleData", type: "bytes", internalType: "bytes" },
-                            { name: "resolutionModuleData", type: "bytes", internalType: "bytes" },
-                            { name: "finalityModuleData", type: "bytes", internalType: "bytes" },
-                        ],
-                    },
-                    {
-                        name: "_response",
-                        type: "tuple",
-                        internalType: "struct IOracle.Response",
-                        components: [
-                            { name: "proposer", type: "address", internalType: "address" },
-                            { name: "requestId", type: "bytes32", internalType: "bytes32" },
-                            { name: "response", type: "bytes", internalType: "bytes" },
-                        ],
-                    },
-                    { name: "_finalizer", type: "address", internalType: "address" },
+                name: "_response",
+                type: "tuple",
+                internalType: "struct IOracle.Response",
+                components: [
+                    { name: "proposer", type: "address", internalType: "address" },
+                    { name: "requestId", type: "bytes32", internalType: "bytes32" },
+                    { name: "response", type: "bytes", internalType: "bytes" },
                 ],
-                outputs: [],
-                stateMutability: "nonpayable",
             },
             {
-                type: "function",
-                name: "getEscalation",
-                inputs: [{ name: "_requestId", type: "bytes32", internalType: "bytes32" }],
-                outputs: [
-                    {
-                        name: "_escalation",
-                        type: "tuple",
-                        internalType: "struct IBondEscalationModule.BondEscalation",
-                        components: [
-                            { name: "disputeId", type: "bytes32", internalType: "bytes32" },
-                            {
-                                name: "status",
-                                type: "uint8",
-                                internalType: "enum IBondEscalationModule.BondEscalationStatus",
-                            },
-                            {
-                                name: "amountOfPledgesForDispute",
-                                type: "uint256",
-                                internalType: "uint256",
-                            },
-                            {
-                                name: "amountOfPledgesAgainstDispute",
-                                type: "uint256",
-                                internalType: "uint256",
-                            },
-                        ],
-                    },
+                name: "_dispute",
+                type: "tuple",
+                internalType: "struct IOracle.Dispute",
+                components: [
+                    { name: "disputer", type: "address", internalType: "address" },
+                    { name: "proposer", type: "address", internalType: "address" },
+                    { name: "responseId", type: "bytes32", internalType: "bytes32" },
+                    { name: "requestId", type: "bytes32", internalType: "bytes32" },
                 ],
-                stateMutability: "view",
             },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "finalizeRequest",
+        inputs: [
             {
-                type: "function",
-                name: "moduleName",
-                inputs: [],
-                outputs: [{ name: "_moduleName", type: "string", internalType: "string" }],
-                stateMutability: "pure",
-            },
-            {
-                type: "function",
-                name: "onDisputeStatusChange",
-                inputs: [
-                    { name: "_disputeId", type: "bytes32", internalType: "bytes32" },
-                    {
-                        name: "_request",
-                        type: "tuple",
-                        internalType: "struct IOracle.Request",
-                        components: [
-                            { name: "nonce", type: "uint96", internalType: "uint96" },
-                            { name: "requester", type: "address", internalType: "address" },
-                            { name: "requestModule", type: "address", internalType: "address" },
-                            { name: "responseModule", type: "address", internalType: "address" },
-                            { name: "disputeModule", type: "address", internalType: "address" },
-                            { name: "resolutionModule", type: "address", internalType: "address" },
-                            { name: "finalityModule", type: "address", internalType: "address" },
-                            { name: "requestModuleData", type: "bytes", internalType: "bytes" },
-                            { name: "responseModuleData", type: "bytes", internalType: "bytes" },
-                            { name: "disputeModuleData", type: "bytes", internalType: "bytes" },
-                            { name: "resolutionModuleData", type: "bytes", internalType: "bytes" },
-                            { name: "finalityModuleData", type: "bytes", internalType: "bytes" },
-                        ],
-                    },
-                    {
-                        name: "",
-                        type: "tuple",
-                        internalType: "struct IOracle.Response",
-                        components: [
-                            { name: "proposer", type: "address", internalType: "address" },
-                            { name: "requestId", type: "bytes32", internalType: "bytes32" },
-                            { name: "response", type: "bytes", internalType: "bytes" },
-                        ],
-                    },
-                    {
-                        name: "_dispute",
-                        type: "tuple",
-                        internalType: "struct IOracle.Dispute",
-                        components: [
-                            { name: "disputer", type: "address", internalType: "address" },
-                            { name: "proposer", type: "address", internalType: "address" },
-                            { name: "responseId", type: "bytes32", internalType: "bytes32" },
-                            { name: "requestId", type: "bytes32", internalType: "bytes32" },
-                        ],
-                    },
+                name: "_request",
+                type: "tuple",
+                internalType: "struct IOracle.Request",
+                components: [
+                    { name: "nonce", type: "uint96", internalType: "uint96" },
+                    { name: "requester", type: "address", internalType: "address" },
+                    { name: "requestModule", type: "address", internalType: "address" },
+                    { name: "responseModule", type: "address", internalType: "address" },
+                    { name: "disputeModule", type: "address", internalType: "address" },
+                    { name: "resolutionModule", type: "address", internalType: "address" },
+                    { name: "finalityModule", type: "address", internalType: "address" },
+                    { name: "requestModuleData", type: "bytes", internalType: "bytes" },
+                    { name: "responseModuleData", type: "bytes", internalType: "bytes" },
+                    { name: "disputeModuleData", type: "bytes", internalType: "bytes" },
+                    { name: "resolutionModuleData", type: "bytes", internalType: "bytes" },
+                    { name: "finalityModuleData", type: "bytes", internalType: "bytes" },
                 ],
-                outputs: [],
-                stateMutability: "nonpayable",
             },
             {
-                type: "function",
-                name: "pledgeAgainstDispute",
-                inputs: [
-                    {
-                        name: "_request",
-                        type: "tuple",
-                        internalType: "struct IOracle.Request",
-                        components: [
-                            { name: "nonce", type: "uint96", internalType: "uint96" },
-                            { name: "requester", type: "address", internalType: "address" },
-                            { name: "requestModule", type: "address", internalType: "address" },
-                            { name: "responseModule", type: "address", internalType: "address" },
-                            { name: "disputeModule", type: "address", internalType: "address" },
-                            { name: "resolutionModule", type: "address", internalType: "address" },
-                            { name: "finalityModule", type: "address", internalType: "address" },
-                            { name: "requestModuleData", type: "bytes", internalType: "bytes" },
-                            { name: "responseModuleData", type: "bytes", internalType: "bytes" },
-                            { name: "disputeModuleData", type: "bytes", internalType: "bytes" },
-                            { name: "resolutionModuleData", type: "bytes", internalType: "bytes" },
-                            { name: "finalityModuleData", type: "bytes", internalType: "bytes" },
-                        ],
-                    },
-                    {
-                        name: "_dispute",
-                        type: "tuple",
-                        internalType: "struct IOracle.Dispute",
-                        components: [
-                            { name: "disputer", type: "address", internalType: "address" },
-                            { name: "proposer", type: "address", internalType: "address" },
-                            { name: "responseId", type: "bytes32", internalType: "bytes32" },
-                            { name: "requestId", type: "bytes32", internalType: "bytes32" },
-                        ],
-                    },
+                name: "_response",
+                type: "tuple",
+                internalType: "struct IOracle.Response",
+                components: [
+                    { name: "proposer", type: "address", internalType: "address" },
+                    { name: "requestId", type: "bytes32", internalType: "bytes32" },
+                    { name: "response", type: "bytes", internalType: "bytes" },
                 ],
-                outputs: [],
-                stateMutability: "nonpayable",
             },
+            { name: "_finalizer", type: "address", internalType: "address" },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "getEscalation",
+        inputs: [{ name: "_requestId", type: "bytes32", internalType: "bytes32" }],
+        outputs: [
             {
-                type: "function",
-                name: "pledgeForDispute",
-                inputs: [
+                name: "_escalation",
+                type: "tuple",
+                internalType: "struct IBondEscalationModule.BondEscalation",
+                components: [
+                    { name: "disputeId", type: "bytes32", internalType: "bytes32" },
                     {
-                        name: "_request",
-                        type: "tuple",
-                        internalType: "struct IOracle.Request",
-                        components: [
-                            { name: "nonce", type: "uint96", internalType: "uint96" },
-                            { name: "requester", type: "address", internalType: "address" },
-                            { name: "requestModule", type: "address", internalType: "address" },
-                            { name: "responseModule", type: "address", internalType: "address" },
-                            { name: "disputeModule", type: "address", internalType: "address" },
-                            { name: "resolutionModule", type: "address", internalType: "address" },
-                            { name: "finalityModule", type: "address", internalType: "address" },
-                            { name: "requestModuleData", type: "bytes", internalType: "bytes" },
-                            { name: "responseModuleData", type: "bytes", internalType: "bytes" },
-                            { name: "disputeModuleData", type: "bytes", internalType: "bytes" },
-                            { name: "resolutionModuleData", type: "bytes", internalType: "bytes" },
-                            { name: "finalityModuleData", type: "bytes", internalType: "bytes" },
-                        ],
-                    },
-                    {
-                        name: "_dispute",
-                        type: "tuple",
-                        internalType: "struct IOracle.Dispute",
-                        components: [
-                            { name: "disputer", type: "address", internalType: "address" },
-                            { name: "proposer", type: "address", internalType: "address" },
-                            { name: "responseId", type: "bytes32", internalType: "bytes32" },
-                            { name: "requestId", type: "bytes32", internalType: "bytes32" },
-                        ],
-                    },
-                ],
-                outputs: [],
-                stateMutability: "nonpayable",
-            },
-            {
-                type: "function",
-                name: "pledgesAgainstDispute",
-                inputs: [
-                    { name: "_requestId", type: "bytes32", internalType: "bytes32" },
-                    { name: "_pledger", type: "address", internalType: "address" },
-                ],
-                outputs: [{ name: "pledges", type: "uint256", internalType: "uint256" }],
-                stateMutability: "view",
-            },
-            {
-                type: "function",
-                name: "pledgesForDispute",
-                inputs: [
-                    { name: "_requestId", type: "bytes32", internalType: "bytes32" },
-                    { name: "_pledger", type: "address", internalType: "address" },
-                ],
-                outputs: [{ name: "pledges", type: "uint256", internalType: "uint256" }],
-                stateMutability: "view",
-            },
-            {
-                type: "function",
-                name: "settleBondEscalation",
-                inputs: [
-                    {
-                        name: "_request",
-                        type: "tuple",
-                        internalType: "struct IOracle.Request",
-                        components: [
-                            { name: "nonce", type: "uint96", internalType: "uint96" },
-                            { name: "requester", type: "address", internalType: "address" },
-                            { name: "requestModule", type: "address", internalType: "address" },
-                            { name: "responseModule", type: "address", internalType: "address" },
-                            { name: "disputeModule", type: "address", internalType: "address" },
-                            { name: "resolutionModule", type: "address", internalType: "address" },
-                            { name: "finalityModule", type: "address", internalType: "address" },
-                            { name: "requestModuleData", type: "bytes", internalType: "bytes" },
-                            { name: "responseModuleData", type: "bytes", internalType: "bytes" },
-                            { name: "disputeModuleData", type: "bytes", internalType: "bytes" },
-                            { name: "resolutionModuleData", type: "bytes", internalType: "bytes" },
-                            { name: "finalityModuleData", type: "bytes", internalType: "bytes" },
-                        ],
-                    },
-                    {
-                        name: "_response",
-                        type: "tuple",
-                        internalType: "struct IOracle.Response",
-                        components: [
-                            { name: "proposer", type: "address", internalType: "address" },
-                            { name: "requestId", type: "bytes32", internalType: "bytes32" },
-                            { name: "response", type: "bytes", internalType: "bytes" },
-                        ],
-                    },
-                    {
-                        name: "_dispute",
-                        type: "tuple",
-                        internalType: "struct IOracle.Dispute",
-                        components: [
-                            { name: "disputer", type: "address", internalType: "address" },
-                            { name: "proposer", type: "address", internalType: "address" },
-                            { name: "responseId", type: "bytes32", internalType: "bytes32" },
-                            { name: "requestId", type: "bytes32", internalType: "bytes32" },
-                        ],
-                    },
-                ],
-                outputs: [],
-                stateMutability: "nonpayable",
-            },
-            {
-                type: "function",
-                name: "validateParameters",
-                inputs: [{ name: "_encodedParameters", type: "bytes", internalType: "bytes" }],
-                outputs: [{ name: "_valid", type: "bool", internalType: "bool" }],
-                stateMutability: "pure",
-            },
-            {
-                type: "event",
-                name: "BondEscalationStatusUpdated",
-                inputs: [
-                    { name: "_requestId", type: "bytes32", indexed: true, internalType: "bytes32" },
-                    { name: "_disputeId", type: "bytes32", indexed: true, internalType: "bytes32" },
-                    {
-                        name: "_status",
+                        name: "status",
                         type: "uint8",
-                        indexed: false,
                         internalType: "enum IBondEscalationModule.BondEscalationStatus",
                     },
-                ],
-                anonymous: false,
-            },
-            {
-                type: "event",
-                name: "DisputeStatusChanged",
-                inputs: [
-                    { name: "_disputeId", type: "bytes32", indexed: true, internalType: "bytes32" },
                     {
-                        name: "_dispute",
-                        type: "tuple",
-                        indexed: false,
-                        internalType: "struct IOracle.Dispute",
-                        components: [
-                            { name: "disputer", type: "address", internalType: "address" },
-                            { name: "proposer", type: "address", internalType: "address" },
-                            { name: "responseId", type: "bytes32", internalType: "bytes32" },
-                            { name: "requestId", type: "bytes32", internalType: "bytes32" },
-                        ],
-                    },
-                    {
-                        name: "_status",
-                        type: "uint8",
-                        indexed: false,
-                        internalType: "enum IOracle.DisputeStatus",
-                    },
-                ],
-                anonymous: false,
-            },
-            {
-                type: "event",
-                name: "PledgedAgainstDispute",
-                inputs: [
-                    { name: "_disputeId", type: "bytes32", indexed: true, internalType: "bytes32" },
-                    { name: "_pledger", type: "address", indexed: true, internalType: "address" },
-                    { name: "_amount", type: "uint256", indexed: true, internalType: "uint256" },
-                ],
-                anonymous: false,
-            },
-            {
-                type: "event",
-                name: "PledgedForDispute",
-                inputs: [
-                    { name: "_disputeId", type: "bytes32", indexed: true, internalType: "bytes32" },
-                    { name: "_pledger", type: "address", indexed: true, internalType: "address" },
-                    { name: "_amount", type: "uint256", indexed: true, internalType: "uint256" },
-                ],
-                anonymous: false,
-            },
-            {
-                type: "event",
-                name: "RequestFinalized",
-                inputs: [
-                    { name: "_requestId", type: "bytes32", indexed: true, internalType: "bytes32" },
-                    {
-                        name: "_response",
-                        type: "tuple",
-                        indexed: false,
-                        internalType: "struct IOracle.Response",
-                        components: [
-                            { name: "proposer", type: "address", internalType: "address" },
-                            { name: "requestId", type: "bytes32", internalType: "bytes32" },
-                            { name: "response", type: "bytes", internalType: "bytes" },
-                        ],
-                    },
-                    {
-                        name: "_finalizer",
-                        type: "address",
-                        indexed: false,
-                        internalType: "address",
-                    },
-                ],
-                anonymous: false,
-            },
-            {
-                type: "event",
-                name: "ResponseDisputed",
-                inputs: [
-                    { name: "_requestId", type: "bytes32", indexed: true, internalType: "bytes32" },
-                    {
-                        name: "_responseId",
-                        type: "bytes32",
-                        indexed: true,
-                        internalType: "bytes32",
-                    },
-                    { name: "_disputeId", type: "bytes32", indexed: true, internalType: "bytes32" },
-                    {
-                        name: "_dispute",
-                        type: "tuple",
-                        indexed: false,
-                        internalType: "struct IOracle.Dispute",
-                        components: [
-                            { name: "disputer", type: "address", internalType: "address" },
-                            { name: "proposer", type: "address", internalType: "address" },
-                            { name: "responseId", type: "bytes32", internalType: "bytes32" },
-                            { name: "requestId", type: "bytes32", internalType: "bytes32" },
-                        ],
-                    },
-                    {
-                        name: "_blockNumber",
+                        name: "amountOfPledgesForDispute",
                         type: "uint256",
-                        indexed: false,
+                        internalType: "uint256",
+                    },
+                    {
+                        name: "amountOfPledgesAgainstDispute",
+                        type: "uint256",
                         internalType: "uint256",
                     },
                 ],
-                anonymous: false,
             },
-            { type: "error", name: "BondEscalationModule_BondEscalationCantBeSettled", inputs: [] },
-            { type: "error", name: "BondEscalationModule_BondEscalationNotOver", inputs: [] },
-            { type: "error", name: "BondEscalationModule_BondEscalationOver", inputs: [] },
-            { type: "error", name: "BondEscalationModule_CanOnlySurpassByOnePledge", inputs: [] },
-            {
-                type: "error",
-                name: "BondEscalationModule_CannotBreakTieDuringTyingBuffer",
-                inputs: [],
-            },
-            { type: "error", name: "BondEscalationModule_DisputeDoesNotExist", inputs: [] },
-            { type: "error", name: "BondEscalationModule_DisputeWindowOver", inputs: [] },
-            { type: "error", name: "BondEscalationModule_InvalidDispute", inputs: [] },
-            { type: "error", name: "BondEscalationModule_InvalidEscalationParameters", inputs: [] },
-            {
-                type: "error",
-                name: "BondEscalationModule_MaxNumberOfEscalationsReached",
-                inputs: [],
-            },
-            { type: "error", name: "BondEscalationModule_NotEscalatable", inputs: [] },
-            { type: "error", name: "BondEscalationModule_ShouldBeEscalated", inputs: [] },
-            { type: "error", name: "BondEscalationModule_ZeroValue", inputs: [] },
-            { type: "error", name: "Module_OnlyOracle", inputs: [] },
-            { type: "error", name: "Validator_InvalidDispute", inputs: [] },
-            { type: "error", name: "Validator_InvalidResponse", inputs: [] },
         ],
-        bytecode: {
-            object: "0x60a06040523480156200001157600080fd5b506040516200295f3803806200295f833981016040819052620000349162000046565b6001600160a01b031660805262000078565b6000602082840312156200005957600080fd5b81516001600160a01b03811681146200007157600080fd5b9392505050565b60805161288c620000d3600039600081816101390152818161044b01528181610511015281816107d601528181610a2a01528181610cdc01528181610de701528181610e9701528181611b2a0152611cf4015261288c6000f3fe608060405234801561001057600080fd5b50600436106100df5760003560e01c80636ec18b8c1161008c578063a93d61c311610066578063a93d61c31461022e578063d12481a414610241578063d58eaf4a146102b7578063ef940cef146102ca57600080fd5b80636ec18b8c146101bc5780637068639f146101cf57806393f0899a146101ef57600080fd5b80633974363f116100bd5780633974363f1461017357806357bf0e3d146101865780636974f58e1461019957600080fd5b8063076404dc146100e4578063088563681461011f57806338013f0214610134575b600080fd5b61010c6100f2366004611dda565b600060208181529281526040808220909352908152205481565b6040519081526020015b60405180910390f35b61013261012d366004611e35565b6102f5565b005b61015b7f000000000000000000000000000000000000000000000000000000000000000081565b6040516001600160a01b039091168152602001610116565b610132610181366004611e96565b610440565b610132610194366004611e35565b61084a565b6101ac6101a7366004611f0b565b610997565b6040519015158152602001610116565b6101326101ca366004611f7d565b610a1f565b6101e26101dd366004611ff5565b610a86565b6040516101169190612051565b604080518082018252601481527f426f6e64457363616c6174696f6e4d6f64756c65000000000000000000000000602082015290516101169190612087565b61013261023c366004611e96565b610b1e565b61025461024f366004611f0b565b610d77565b6040516101169190600060e0820190506001600160a01b038084511683528060208501511660208401525060408301516040830152606083015160608301526080830151608083015260a083015160a083015260c083015160c083015292915050565b6101326102c53660046120f3565b610ddc565b61010c6102d8366004611dda565b600160209081526000928352604080842090915290825290205481565b60006103008261171c565b90506000610310848460016117b6565b905060016002600085606001358152602001908152602001600020600201600082825461033d9190612172565b90915550506060830135600090815260208181526040808320338452909152812080546001929061036f908490612172565b90915550508051602082015160408084015190517f563cd0fb0000000000000000000000000000000000000000000000000000000081526001600160a01b039093169263563cd0fb926103cc9233928a928a929091600401612440565b600060405180830381600087803b1580156103e657600080fd5b505af11580156103fa573d6000803e3d6000fd5b505050508060400151336001600160a01b0316837f9355e66a627cc34b6a1d0505f4ad87ed87f047e962d5f6efe3d7deafb6c8873c60405160405180910390a450505050565b336001600160a01b037f000000000000000000000000000000000000000000000000000000000000000016146104a2576040517fbb44f97c00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b60006104ad8261171c565b905060006104c261024f61012087018761248d565b60608401356000908152600260205260409081902060c083015182517f12dddcd000000000000000000000000000000000000000000000000000000000815292870135600484015292935091907f00000000000000000000000000000000000000000000000000000000000000006001600160a01b0316906312dddcd090602401602060405180830381865afa158015610560573d6000803e3d6000fd5b505050506040513d601f19601f8201168201806040525081019061058491906124f2565b6fffffffffffffffffffffffffffffffff166105a09190612172565b4311156105d9576040517fc1485a8000000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b81516001600160a01b031663bba9f26f6105f66020870187612524565b602085015160408087015190517fffffffff0000000000000000000000000000000000000000000000000000000060e086901b1681526001600160a01b03938416600482015260608a013560248201529290911660448301526064820152608401600060405180830381600087803b15801561067157600080fd5b505af1158015610685573d6000803e3d6000fd5b5050505082846040013585606001357f589c42fe80d76b85c8fd3e77ad169d80504878503ebe88728b77a6be9d7fb70e87436040516106c5929190612541565b60405180910390a46000600182015460ff1660048111156106e8576106e861200e565b0361079e57816080015142111561072b576040517fd53b827d00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b600181810180547fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00168217905583825560405184916060870135917f7321d41e15b6e1528c11d6a510979859cdbecc491a1b5f248ac7ac37f6d93ee6916107919161255c565b60405180910390a3610842565b80548314610842576040517fdca761630000000000000000000000000000000000000000000000000000000081526001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000169063dca761639061080f908990899089906004016125b7565b600060405180830381600087803b15801561082957600080fd5b505af115801561083d573d6000803e3d6000fd5b505050505b505050505050565b60006108558261171c565b90506000610865848460006117b6565b90506001600260008560600135815260200190815260200160002060030160008282546108929190612172565b90915550506060830135600090815260016020818152604080842033855290915282208054919290916108c6908490612172565b90915550508051602082015160408084015190517f563cd0fb0000000000000000000000000000000000000000000000000000000081526001600160a01b039093169263563cd0fb926109239233928a928a929091600401612440565b600060405180830381600087803b15801561093d57600080fd5b505af1158015610951573d6000803e3d6000fd5b505050508060400151336001600160a01b0316837f33c895a610e2cf805d42e23ce2fcb45ba058a126181657fd4b76ffde4b8faf4060405160405180910390a450505050565b6000806109a48484610d77565b80519091506001600160a01b0316158015906109cc575060208101516001600160a01b031615155b80156109db5750604081015115155b80156109ea5750608081015115155b80156109f95750606081015115155b8015610a08575060a081015115155b8015610a17575060c081015115155b949350505050565b336001600160a01b037f00000000000000000000000000000000000000000000000000000000000000001614610a81576040517fbb44f97c00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b505050565b610ab2604080516080810190915260008082526020820190815260200160008152602001600081525090565b600082815260026020908152604091829020825160808101909352805483526001810154909183019060ff166004811115610aef57610aef61200e565b6004811115610b0057610b0061200e565b81526002820154602082015260039091015460409091015292915050565b6000610b2b848484611a78565b915060009050610b4261024f61012087018761248d565b6060840135600090815260026020526040902060a082015160808301519293509091610b6e9190612172565b4211610ba6576040517f3dec5dcf00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b60018082015460ff166004811115610bc057610bc061200e565b14610bf7576040517f7b45fd7100000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b60028101546003820154808203610c3a576040517fba7a57f300000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b80821180610c49576003610c4c565b60045b6001808601805490917fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0090911690836004811115610c8c57610c8c61200e565b02179055506001840154604051879160608a0135917f7321d41e15b6e1528c11d6a510979859cdbecc491a1b5f248ac7ac37f6d93ee691610cd29160ff9091169061255c565b60405180910390a37f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031663c2120f3a8a8a8a85610d18576004610d1b565b60035b6040518563ffffffff1660e01b8152600401610d3a94939291906125fc565b600060405180830381600087803b158015610d5457600080fd5b505af1158015610d68573d6000803e3d6000fd5b50505050505050505050505050565b610dc96040518060e0016040528060006001600160a01b0316815260200160006001600160a01b0316815260200160008152602001600081526020016000815260200160008152602001600081525090565b610dd58284018461263e565b9392505050565b336001600160a01b037f00000000000000000000000000000000000000000000000000000000000000001614610e3e576040517fbb44f97c00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b6000610e5161024f61012086018661248d565b606083013560009081526002602052604080822090517f8aa202f400000000000000000000000000000000000000000000000000000000815260048101899052929350917f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031690638aa202f490602401602060405180830381865afa158015610ee6573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190610f0a91906126f5565b905060008260000154880361141b576002826005811115610f2d57610f2d61200e565b03610fdd5783608001514211610f6f576040517f3dec5dcf00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b60018084015460ff166004811115610f8957610f8961200e565b141580610f9e57508260030154836002015414155b15610fd5576040517f6c886a9300000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b506002611656565b6005826005811115610ff157610ff161200e565b0361115157600290506000836003015484600201546110109190612172565b111561109c5783600001516001600160a01b031663f2a690cb888787602001518860400151886003015489600201546110499190612172565b6040518663ffffffff1660e01b8152600401611069959493929190612716565b600060405180830381600087803b15801561108357600080fd5b505af1158015611097573d6000803e3d6000fd5b505050505b83516001600160a01b031663a6d09dc86110b96020880188612524565b602087015160408089015190517fffffffff0000000000000000000000000000000000000000000000000000000060e086901b1681526001600160a01b03938416600482015260608b013560248201529290911660448301526064820152608401600060405180830381600087803b15801561113457600080fd5b505af1158015611148573d6000803e3d6000fd5b50505050611656565b600060038360058111156111675761116761200e565b14905080611176576003611179565b60045b6002850154600386015491935090801515806111955750600082115b15611260576000836111c4576111b083896040015184611bf0565b88604001516111bf9190612172565b6111e2565b6111d382896040015185611bf0565b88604001516111e29190612172565b905087600001516001600160a01b031663f2a690cb8c8b8b60200151858961120a578761120c565b885b6040518663ffffffff1660e01b815260040161122c959493929190612716565b600060405180830381600087803b15801561124657600080fd5b505af115801561125a573d6000803e3d6000fd5b50505050505b86516001600160a01b031663cab0e41860608a01358561128c5761128760208c018c612524565b61129c565b61129c60408c0160208d01612524565b866112b6576112b160408d0160208e01612524565b6112c3565b6112c360208d018d612524565b60208c01516040808e015190517fffffffff0000000000000000000000000000000000000000000000000000000060e088901b16815260048101959095526001600160a01b0393841660248601529183166044850152919091166064830152608482015260a401600060405180830381600087803b15801561134457600080fd5b505af1158015611358573d6000803e3d6000fd5b5050505082156114135786516001600160a01b031663a6d09dc861137f60208b018b612524565b60208a01516040808c015190517fffffffff0000000000000000000000000000000000000000000000000000000060e086901b1681526001600160a01b03938416600482015260608e013560248201529290911660448301526064820152608401600060405180830381600087803b1580156113fa57600080fd5b505af115801561140e573d6000803e3d6000fd5b505050505b505050611656565b600282600581111561142f5761142f61200e565b0361143c57506002611656565b60058260058111156114505761145061200e565b03611476575082516002906001600160a01b031663a6d09dc86110b96020880188612524565b6000600383600581111561148c5761148c61200e565b1490508061149b57600361149e565b60045b85519092506001600160a01b031663cab0e4186060880135836114cd576114c860208a018a612524565b6114dd565b6114dd60408a0160208b01612524565b846114f7576114f260408b0160208c01612524565b611504565b61150460208b018b612524565b60208a01516040808c015190517fffffffff0000000000000000000000000000000000000000000000000000000060e088901b16815260048101959095526001600160a01b0393841660248601529183166044850152919091166064830152608482015260a401600060405180830381600087803b15801561158557600080fd5b505af1158015611599573d6000803e3d6000fd5b5050505080156116545784516001600160a01b031663a6d09dc86115c06020890189612524565b60208801516040808a015190517fffffffff0000000000000000000000000000000000000000000000000000000060e086901b1681526001600160a01b03938416600482015260608c013560248201529290911660448301526064820152608401600060405180830381600087803b15801561163b57600080fd5b505af115801561164f573d6000803e3d6000fd5b505050505b505b6001808401805483927fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00909116908360048111156116965761169661200e565b02179055508785606001357f7321d41e15b6e1528c11d6a510979859cdbecc491a1b5f248ac7ac37f6d93ee6836040516116d0919061255c565b60405180910390a3877febec46e3838c1dd8ea4a619ae628d10549e689d60809c63573acbe1c004fec75868460405161170a92919061275f565b60405180910390a25050505050505050565b6040517fef37aa6700000000000000000000000000000000000000000000000000000000815260009073__$8e01d6d44dfa1a05e9d12114a53eb7e1e5$__9063ef37aa679061176f90859060040161277a565b602060405180830381865af415801561178c573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906117b09190612788565b92915050565b6118086040518060e0016040528060006001600160a01b0316815260200160006001600160a01b0316815260200160008152602001600081526020016000815260200160008152602001600081525090565b60006118148585611c2c565b60608501356000908152600260209081526040808320815160808101909252805482526001810154949550929390929183019060ff16600481111561185b5761185b61200e565b600481111561186c5761186c61200e565b815260028201546020820152600390910154604090910152805190915082146118c1576040517fd63a42f100000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b6118d261024f61012088018861248d565b92508260a0015183608001516118e89190612172565b421115611921576040517fd53b827d00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b6040810151606082015185156119ad578460600151820361196e576040517f87459fd700000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b808211156119a8576040517f752e057300000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b611a24565b846060015181036119ea576040517f87459fd700000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b81811115611a24576040517f752e057300000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b846080015142118015611a3657508082145b15611a6d576040517f619fad6e00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b505050509392505050565b60008073__$8e01d6d44dfa1a05e9d12114a53eb7e1e5$__632d9865e28686866040518463ffffffff1660e01b8152600401611ab6939291906127a1565b6040805180830381865af4158015611ad2573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190611af69190612810565b6040517f77b714a70000000000000000000000000000000000000000000000000000000081526004810182905291935091507f00000000000000000000000000000000000000000000000000000000000000006001600160a01b0316906377b714a790602401602060405180830381865afa158015611b79573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190611b9d91906124f2565b6fffffffffffffffffffffffffffffffff16600003611be8576040517fb50031a500000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b935093915050565b6000827fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0484118302158202611c2557600080fd5b5091020490565b6040517f22c9576d00000000000000000000000000000000000000000000000000000000815260009073__$8e01d6d44dfa1a05e9d12114a53eb7e1e5$__906322c9576d90611c819086908690600401612834565b602060405180830381865af4158015611c9e573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190611cc29190612788565b6040517f77b714a7000000000000000000000000000000000000000000000000000000008152600481018290529091507f00000000000000000000000000000000000000000000000000000000000000006001600160a01b0316906377b714a790602401602060405180830381865afa158015611d43573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190611d6791906124f2565b6fffffffffffffffffffffffffffffffff166000036117b0576040517fb50031a500000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b6001600160a01b0381168114611dc757600080fd5b50565b8035611dd581611db2565b919050565b60008060408385031215611ded57600080fd5b823591506020830135611dff81611db2565b809150509250929050565b60006101808284031215611e1d57600080fd5b50919050565b600060808284031215611e1d57600080fd5b60008060a08385031215611e4857600080fd5b823567ffffffffffffffff811115611e5f57600080fd5b611e6b85828601611e0a565b925050611e7b8460208501611e23565b90509250929050565b600060608284031215611e1d57600080fd5b600080600060c08486031215611eab57600080fd5b833567ffffffffffffffff80821115611ec357600080fd5b611ecf87838801611e0a565b94506020860135915080821115611ee557600080fd5b50611ef286828701611e84565b925050611f028560408601611e23565b90509250925092565b60008060208385031215611f1e57600080fd5b823567ffffffffffffffff80821115611f3657600080fd5b818501915085601f830112611f4a57600080fd5b813581811115611f5957600080fd5b866020828501011115611f6b57600080fd5b60209290920196919550909350505050565b600080600060608486031215611f9257600080fd5b833567ffffffffffffffff80821115611faa57600080fd5b611fb687838801611e0a565b94506020860135915080821115611fcc57600080fd5b50611fd986828701611e84565b9250506040840135611fea81611db2565b809150509250925092565b60006020828403121561200757600080fd5b5035919050565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052602160045260246000fd5b6005811061204d5761204d61200e565b9052565b81518152602080830151608083019161206c9084018261203d565b50604083015160408301526060830151606083015292915050565b600060208083528351808285015260005b818110156120b457858101830151858201604001528201612098565b5060006040828601015260407fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0601f8301168501019250505092915050565b60008060008060e0858703121561210957600080fd5b84359350602085013567ffffffffffffffff8082111561212857600080fd5b61213488838901611e0a565b9450604087013591508082111561214a57600080fd5b5061215787828801611e84565b9250506121678660608701611e23565b905092959194509250565b808201808211156117b0577f4e487b7100000000000000000000000000000000000000000000000000000000600052601160045260246000fd5b80356bffffffffffffffffffffffff81168114611dd557600080fd5b60008083357fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe18436030181126121fd57600080fd5b830160208101925035905067ffffffffffffffff81111561221d57600080fd5b80360382131561222c57600080fd5b9250929050565b8183528181602085013750600060208284010152600060207fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0601f840116840101905092915050565b60006101806122a08461228e856121ac565b6bffffffffffffffffffffffff169052565b6122ac60208401611dca565b6001600160a01b031660208501526122c660408401611dca565b6001600160a01b031660408501526122e060608401611dca565b6001600160a01b031660608501526122fa60808401611dca565b6001600160a01b0316608085015261231460a08401611dca565b6001600160a01b031660a085015261232e60c08401611dca565b6001600160a01b031660c085015261234960e08401846121c8565b8260e087015261235c8387018284612233565b9250505061010061236f818501856121c8565b86840383880152612381848284612233565b9350505050610120612395818501856121c8565b868403838801526123a7848284612233565b93505050506101406123bb818501856121c8565b868403838801526123cd848284612233565b93505050506101606123e1818501856121c8565b868403838801526123f3848284612233565b979650505050505050565b803561240981611db2565b6001600160a01b03908116835260208201359061242582611db2565b16602083015260408181013590830152606090810135910152565b60006101006001600160a01b0380891684528160208501526124648285018961227c565b925061247360408501886123fe565b80861660c085015250508260e08301529695505050505050565b60008083357fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe18436030181126124c257600080fd5b83018035915067ffffffffffffffff8211156124dd57600080fd5b60200191503681900382131561222c57600080fd5b60006020828403121561250457600080fd5b81516fffffffffffffffffffffffffffffffff81168114610dd557600080fd5b60006020828403121561253657600080fd5b8135610dd581611db2565b60a0810161254f82856123fe565b8260808301529392505050565b602081016117b0828461203d565b6000813561257781611db2565b6001600160a01b031683526020828101359084015261259960408301836121c8565b606060408601526125ae606086018284612233565b95945050505050565b60c0815260006125ca60c083018661227c565b82810360208401526125dc818661256a565b915050610a1760408301846123fe565b6006811061204d5761204d61200e565b60e08152600061260f60e083018761227c565b8281036020840152612621818761256a565b91505061263160408301856123fe565b6125ae60c08301846125ec565b600060e0828403121561265057600080fd5b60405160e0810181811067ffffffffffffffff8211171561269a577f4e487b7100000000000000000000000000000000000000000000000000000000600052604160045260246000fd5b6040526126a683611dca565b81526126b460208401611dca565b602082015260408301356040820152606083013560608201526080830135608082015260a083013560a082015260c083013560c08201528091505092915050565b60006020828403121561270757600080fd5b815160068110610dd557600080fd5b600061010080835261272a8184018961227c565b91505061273a60208301876123fe565b6001600160a01b03851660a08301528360c08301528260e08301529695505050505050565b60a0810161276d82856123fe565b610dd560808301846125ec565b608081016117b082846123fe565b60006020828403121561279a57600080fd5b5051919050565b60c0815260006127b460c083018661227c565b828103602084015284356127c781611db2565b6001600160a01b03168152602085810135908201526127e960408601866121c8565b606060408401526127fe606084018284612233565b9350505050610a1760408301846123fe565b6000806040838503121561282357600080fd5b505080516020909101519092909150565b60a08152600061284760a083018561227c565b9050610dd560208301846123fe56fea2646970667358221220c37ba6c4485eb16b6178756c9b00b9891c4ee952f5591c57ecac8750e9da113164736f6c63430008130033",
-            sourceMap:
-                "412:14182:51:-:0;;;925:47;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;-1:-1:-1;;;;;332:16:2;;;412:14182:51;;14:306:123;100:6;153:2;141:9;132:7;128:23;124:32;121:52;;;169:1;166;159:12;121:52;195:16;;-1:-1:-1;;;;;240:31:123;;230:42;;220:70;;286:1;283;276:12;220:70;309:5;14:306;-1:-1:-1;;;14:306:123:o;:::-;412:14182:51;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;",
-            linkReferences: {
-                "node_modules/@defi-wonderland/prophet-core/solidity/libraries/ValidatorLib.sol": {
-                    ValidatorLib: [
-                        { start: 6170, length: 20 },
-                        { start: 6992, length: 20 },
-                        { start: 7466, length: 20 },
-                    ],
-                },
-            },
-        },
-        deployedBytecode: {
-            object: "0x608060405234801561001057600080fd5b50600436106100df5760003560e01c80636ec18b8c1161008c578063a93d61c311610066578063a93d61c31461022e578063d12481a414610241578063d58eaf4a146102b7578063ef940cef146102ca57600080fd5b80636ec18b8c146101bc5780637068639f146101cf57806393f0899a146101ef57600080fd5b80633974363f116100bd5780633974363f1461017357806357bf0e3d146101865780636974f58e1461019957600080fd5b8063076404dc146100e4578063088563681461011f57806338013f0214610134575b600080fd5b61010c6100f2366004611dda565b600060208181529281526040808220909352908152205481565b6040519081526020015b60405180910390f35b61013261012d366004611e35565b6102f5565b005b61015b7f000000000000000000000000000000000000000000000000000000000000000081565b6040516001600160a01b039091168152602001610116565b610132610181366004611e96565b610440565b610132610194366004611e35565b61084a565b6101ac6101a7366004611f0b565b610997565b6040519015158152602001610116565b6101326101ca366004611f7d565b610a1f565b6101e26101dd366004611ff5565b610a86565b6040516101169190612051565b604080518082018252601481527f426f6e64457363616c6174696f6e4d6f64756c65000000000000000000000000602082015290516101169190612087565b61013261023c366004611e96565b610b1e565b61025461024f366004611f0b565b610d77565b6040516101169190600060e0820190506001600160a01b038084511683528060208501511660208401525060408301516040830152606083015160608301526080830151608083015260a083015160a083015260c083015160c083015292915050565b6101326102c53660046120f3565b610ddc565b61010c6102d8366004611dda565b600160209081526000928352604080842090915290825290205481565b60006103008261171c565b90506000610310848460016117b6565b905060016002600085606001358152602001908152602001600020600201600082825461033d9190612172565b90915550506060830135600090815260208181526040808320338452909152812080546001929061036f908490612172565b90915550508051602082015160408084015190517f563cd0fb0000000000000000000000000000000000000000000000000000000081526001600160a01b039093169263563cd0fb926103cc9233928a928a929091600401612440565b600060405180830381600087803b1580156103e657600080fd5b505af11580156103fa573d6000803e3d6000fd5b505050508060400151336001600160a01b0316837f9355e66a627cc34b6a1d0505f4ad87ed87f047e962d5f6efe3d7deafb6c8873c60405160405180910390a450505050565b336001600160a01b037f000000000000000000000000000000000000000000000000000000000000000016146104a2576040517fbb44f97c00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b60006104ad8261171c565b905060006104c261024f61012087018761248d565b60608401356000908152600260205260409081902060c083015182517f12dddcd000000000000000000000000000000000000000000000000000000000815292870135600484015292935091907f00000000000000000000000000000000000000000000000000000000000000006001600160a01b0316906312dddcd090602401602060405180830381865afa158015610560573d6000803e3d6000fd5b505050506040513d601f19601f8201168201806040525081019061058491906124f2565b6fffffffffffffffffffffffffffffffff166105a09190612172565b4311156105d9576040517fc1485a8000000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b81516001600160a01b031663bba9f26f6105f66020870187612524565b602085015160408087015190517fffffffff0000000000000000000000000000000000000000000000000000000060e086901b1681526001600160a01b03938416600482015260608a013560248201529290911660448301526064820152608401600060405180830381600087803b15801561067157600080fd5b505af1158015610685573d6000803e3d6000fd5b5050505082846040013585606001357f589c42fe80d76b85c8fd3e77ad169d80504878503ebe88728b77a6be9d7fb70e87436040516106c5929190612541565b60405180910390a46000600182015460ff1660048111156106e8576106e861200e565b0361079e57816080015142111561072b576040517fd53b827d00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b600181810180547fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00168217905583825560405184916060870135917f7321d41e15b6e1528c11d6a510979859cdbecc491a1b5f248ac7ac37f6d93ee6916107919161255c565b60405180910390a3610842565b80548314610842576040517fdca761630000000000000000000000000000000000000000000000000000000081526001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000169063dca761639061080f908990899089906004016125b7565b600060405180830381600087803b15801561082957600080fd5b505af115801561083d573d6000803e3d6000fd5b505050505b505050505050565b60006108558261171c565b90506000610865848460006117b6565b90506001600260008560600135815260200190815260200160002060030160008282546108929190612172565b90915550506060830135600090815260016020818152604080842033855290915282208054919290916108c6908490612172565b90915550508051602082015160408084015190517f563cd0fb0000000000000000000000000000000000000000000000000000000081526001600160a01b039093169263563cd0fb926109239233928a928a929091600401612440565b600060405180830381600087803b15801561093d57600080fd5b505af1158015610951573d6000803e3d6000fd5b505050508060400151336001600160a01b0316837f33c895a610e2cf805d42e23ce2fcb45ba058a126181657fd4b76ffde4b8faf4060405160405180910390a450505050565b6000806109a48484610d77565b80519091506001600160a01b0316158015906109cc575060208101516001600160a01b031615155b80156109db5750604081015115155b80156109ea5750608081015115155b80156109f95750606081015115155b8015610a08575060a081015115155b8015610a17575060c081015115155b949350505050565b336001600160a01b037f00000000000000000000000000000000000000000000000000000000000000001614610a81576040517fbb44f97c00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b505050565b610ab2604080516080810190915260008082526020820190815260200160008152602001600081525090565b600082815260026020908152604091829020825160808101909352805483526001810154909183019060ff166004811115610aef57610aef61200e565b6004811115610b0057610b0061200e565b81526002820154602082015260039091015460409091015292915050565b6000610b2b848484611a78565b915060009050610b4261024f61012087018761248d565b6060840135600090815260026020526040902060a082015160808301519293509091610b6e9190612172565b4211610ba6576040517f3dec5dcf00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b60018082015460ff166004811115610bc057610bc061200e565b14610bf7576040517f7b45fd7100000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b60028101546003820154808203610c3a576040517fba7a57f300000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b80821180610c49576003610c4c565b60045b6001808601805490917fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0090911690836004811115610c8c57610c8c61200e565b02179055506001840154604051879160608a0135917f7321d41e15b6e1528c11d6a510979859cdbecc491a1b5f248ac7ac37f6d93ee691610cd29160ff9091169061255c565b60405180910390a37f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031663c2120f3a8a8a8a85610d18576004610d1b565b60035b6040518563ffffffff1660e01b8152600401610d3a94939291906125fc565b600060405180830381600087803b158015610d5457600080fd5b505af1158015610d68573d6000803e3d6000fd5b50505050505050505050505050565b610dc96040518060e0016040528060006001600160a01b0316815260200160006001600160a01b0316815260200160008152602001600081526020016000815260200160008152602001600081525090565b610dd58284018461263e565b9392505050565b336001600160a01b037f00000000000000000000000000000000000000000000000000000000000000001614610e3e576040517fbb44f97c00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b6000610e5161024f61012086018661248d565b606083013560009081526002602052604080822090517f8aa202f400000000000000000000000000000000000000000000000000000000815260048101899052929350917f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031690638aa202f490602401602060405180830381865afa158015610ee6573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190610f0a91906126f5565b905060008260000154880361141b576002826005811115610f2d57610f2d61200e565b03610fdd5783608001514211610f6f576040517f3dec5dcf00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b60018084015460ff166004811115610f8957610f8961200e565b141580610f9e57508260030154836002015414155b15610fd5576040517f6c886a9300000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b506002611656565b6005826005811115610ff157610ff161200e565b0361115157600290506000836003015484600201546110109190612172565b111561109c5783600001516001600160a01b031663f2a690cb888787602001518860400151886003015489600201546110499190612172565b6040518663ffffffff1660e01b8152600401611069959493929190612716565b600060405180830381600087803b15801561108357600080fd5b505af1158015611097573d6000803e3d6000fd5b505050505b83516001600160a01b031663a6d09dc86110b96020880188612524565b602087015160408089015190517fffffffff0000000000000000000000000000000000000000000000000000000060e086901b1681526001600160a01b03938416600482015260608b013560248201529290911660448301526064820152608401600060405180830381600087803b15801561113457600080fd5b505af1158015611148573d6000803e3d6000fd5b50505050611656565b600060038360058111156111675761116761200e565b14905080611176576003611179565b60045b6002850154600386015491935090801515806111955750600082115b15611260576000836111c4576111b083896040015184611bf0565b88604001516111bf9190612172565b6111e2565b6111d382896040015185611bf0565b88604001516111e29190612172565b905087600001516001600160a01b031663f2a690cb8c8b8b60200151858961120a578761120c565b885b6040518663ffffffff1660e01b815260040161122c959493929190612716565b600060405180830381600087803b15801561124657600080fd5b505af115801561125a573d6000803e3d6000fd5b50505050505b86516001600160a01b031663cab0e41860608a01358561128c5761128760208c018c612524565b61129c565b61129c60408c0160208d01612524565b866112b6576112b160408d0160208e01612524565b6112c3565b6112c360208d018d612524565b60208c01516040808e015190517fffffffff0000000000000000000000000000000000000000000000000000000060e088901b16815260048101959095526001600160a01b0393841660248601529183166044850152919091166064830152608482015260a401600060405180830381600087803b15801561134457600080fd5b505af1158015611358573d6000803e3d6000fd5b5050505082156114135786516001600160a01b031663a6d09dc861137f60208b018b612524565b60208a01516040808c015190517fffffffff0000000000000000000000000000000000000000000000000000000060e086901b1681526001600160a01b03938416600482015260608e013560248201529290911660448301526064820152608401600060405180830381600087803b1580156113fa57600080fd5b505af115801561140e573d6000803e3d6000fd5b505050505b505050611656565b600282600581111561142f5761142f61200e565b0361143c57506002611656565b60058260058111156114505761145061200e565b03611476575082516002906001600160a01b031663a6d09dc86110b96020880188612524565b6000600383600581111561148c5761148c61200e565b1490508061149b57600361149e565b60045b85519092506001600160a01b031663cab0e4186060880135836114cd576114c860208a018a612524565b6114dd565b6114dd60408a0160208b01612524565b846114f7576114f260408b0160208c01612524565b611504565b61150460208b018b612524565b60208a01516040808c015190517fffffffff0000000000000000000000000000000000000000000000000000000060e088901b16815260048101959095526001600160a01b0393841660248601529183166044850152919091166064830152608482015260a401600060405180830381600087803b15801561158557600080fd5b505af1158015611599573d6000803e3d6000fd5b5050505080156116545784516001600160a01b031663a6d09dc86115c06020890189612524565b60208801516040808a015190517fffffffff0000000000000000000000000000000000000000000000000000000060e086901b1681526001600160a01b03938416600482015260608c013560248201529290911660448301526064820152608401600060405180830381600087803b15801561163b57600080fd5b505af115801561164f573d6000803e3d6000fd5b505050505b505b6001808401805483927fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00909116908360048111156116965761169661200e565b02179055508785606001357f7321d41e15b6e1528c11d6a510979859cdbecc491a1b5f248ac7ac37f6d93ee6836040516116d0919061255c565b60405180910390a3877febec46e3838c1dd8ea4a619ae628d10549e689d60809c63573acbe1c004fec75868460405161170a92919061275f565b60405180910390a25050505050505050565b6040517fef37aa6700000000000000000000000000000000000000000000000000000000815260009073__$8e01d6d44dfa1a05e9d12114a53eb7e1e5$__9063ef37aa679061176f90859060040161277a565b602060405180830381865af415801561178c573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906117b09190612788565b92915050565b6118086040518060e0016040528060006001600160a01b0316815260200160006001600160a01b0316815260200160008152602001600081526020016000815260200160008152602001600081525090565b60006118148585611c2c565b60608501356000908152600260209081526040808320815160808101909252805482526001810154949550929390929183019060ff16600481111561185b5761185b61200e565b600481111561186c5761186c61200e565b815260028201546020820152600390910154604090910152805190915082146118c1576040517fd63a42f100000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b6118d261024f61012088018861248d565b92508260a0015183608001516118e89190612172565b421115611921576040517fd53b827d00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b6040810151606082015185156119ad578460600151820361196e576040517f87459fd700000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b808211156119a8576040517f752e057300000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b611a24565b846060015181036119ea576040517f87459fd700000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b81811115611a24576040517f752e057300000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b846080015142118015611a3657508082145b15611a6d576040517f619fad6e00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b505050509392505050565b60008073__$8e01d6d44dfa1a05e9d12114a53eb7e1e5$__632d9865e28686866040518463ffffffff1660e01b8152600401611ab6939291906127a1565b6040805180830381865af4158015611ad2573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190611af69190612810565b6040517f77b714a70000000000000000000000000000000000000000000000000000000081526004810182905291935091507f00000000000000000000000000000000000000000000000000000000000000006001600160a01b0316906377b714a790602401602060405180830381865afa158015611b79573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190611b9d91906124f2565b6fffffffffffffffffffffffffffffffff16600003611be8576040517fb50031a500000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b935093915050565b6000827fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0484118302158202611c2557600080fd5b5091020490565b6040517f22c9576d00000000000000000000000000000000000000000000000000000000815260009073__$8e01d6d44dfa1a05e9d12114a53eb7e1e5$__906322c9576d90611c819086908690600401612834565b602060405180830381865af4158015611c9e573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190611cc29190612788565b6040517f77b714a7000000000000000000000000000000000000000000000000000000008152600481018290529091507f00000000000000000000000000000000000000000000000000000000000000006001600160a01b0316906377b714a790602401602060405180830381865afa158015611d43573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190611d6791906124f2565b6fffffffffffffffffffffffffffffffff166000036117b0576040517fb50031a500000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b6001600160a01b0381168114611dc757600080fd5b50565b8035611dd581611db2565b919050565b60008060408385031215611ded57600080fd5b823591506020830135611dff81611db2565b809150509250929050565b60006101808284031215611e1d57600080fd5b50919050565b600060808284031215611e1d57600080fd5b60008060a08385031215611e4857600080fd5b823567ffffffffffffffff811115611e5f57600080fd5b611e6b85828601611e0a565b925050611e7b8460208501611e23565b90509250929050565b600060608284031215611e1d57600080fd5b600080600060c08486031215611eab57600080fd5b833567ffffffffffffffff80821115611ec357600080fd5b611ecf87838801611e0a565b94506020860135915080821115611ee557600080fd5b50611ef286828701611e84565b925050611f028560408601611e23565b90509250925092565b60008060208385031215611f1e57600080fd5b823567ffffffffffffffff80821115611f3657600080fd5b818501915085601f830112611f4a57600080fd5b813581811115611f5957600080fd5b866020828501011115611f6b57600080fd5b60209290920196919550909350505050565b600080600060608486031215611f9257600080fd5b833567ffffffffffffffff80821115611faa57600080fd5b611fb687838801611e0a565b94506020860135915080821115611fcc57600080fd5b50611fd986828701611e84565b9250506040840135611fea81611db2565b809150509250925092565b60006020828403121561200757600080fd5b5035919050565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052602160045260246000fd5b6005811061204d5761204d61200e565b9052565b81518152602080830151608083019161206c9084018261203d565b50604083015160408301526060830151606083015292915050565b600060208083528351808285015260005b818110156120b457858101830151858201604001528201612098565b5060006040828601015260407fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0601f8301168501019250505092915050565b60008060008060e0858703121561210957600080fd5b84359350602085013567ffffffffffffffff8082111561212857600080fd5b61213488838901611e0a565b9450604087013591508082111561214a57600080fd5b5061215787828801611e84565b9250506121678660608701611e23565b905092959194509250565b808201808211156117b0577f4e487b7100000000000000000000000000000000000000000000000000000000600052601160045260246000fd5b80356bffffffffffffffffffffffff81168114611dd557600080fd5b60008083357fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe18436030181126121fd57600080fd5b830160208101925035905067ffffffffffffffff81111561221d57600080fd5b80360382131561222c57600080fd5b9250929050565b8183528181602085013750600060208284010152600060207fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0601f840116840101905092915050565b60006101806122a08461228e856121ac565b6bffffffffffffffffffffffff169052565b6122ac60208401611dca565b6001600160a01b031660208501526122c660408401611dca565b6001600160a01b031660408501526122e060608401611dca565b6001600160a01b031660608501526122fa60808401611dca565b6001600160a01b0316608085015261231460a08401611dca565b6001600160a01b031660a085015261232e60c08401611dca565b6001600160a01b031660c085015261234960e08401846121c8565b8260e087015261235c8387018284612233565b9250505061010061236f818501856121c8565b86840383880152612381848284612233565b9350505050610120612395818501856121c8565b868403838801526123a7848284612233565b93505050506101406123bb818501856121c8565b868403838801526123cd848284612233565b93505050506101606123e1818501856121c8565b868403838801526123f3848284612233565b979650505050505050565b803561240981611db2565b6001600160a01b03908116835260208201359061242582611db2565b16602083015260408181013590830152606090810135910152565b60006101006001600160a01b0380891684528160208501526124648285018961227c565b925061247360408501886123fe565b80861660c085015250508260e08301529695505050505050565b60008083357fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe18436030181126124c257600080fd5b83018035915067ffffffffffffffff8211156124dd57600080fd5b60200191503681900382131561222c57600080fd5b60006020828403121561250457600080fd5b81516fffffffffffffffffffffffffffffffff81168114610dd557600080fd5b60006020828403121561253657600080fd5b8135610dd581611db2565b60a0810161254f82856123fe565b8260808301529392505050565b602081016117b0828461203d565b6000813561257781611db2565b6001600160a01b031683526020828101359084015261259960408301836121c8565b606060408601526125ae606086018284612233565b95945050505050565b60c0815260006125ca60c083018661227c565b82810360208401526125dc818661256a565b915050610a1760408301846123fe565b6006811061204d5761204d61200e565b60e08152600061260f60e083018761227c565b8281036020840152612621818761256a565b91505061263160408301856123fe565b6125ae60c08301846125ec565b600060e0828403121561265057600080fd5b60405160e0810181811067ffffffffffffffff8211171561269a577f4e487b7100000000000000000000000000000000000000000000000000000000600052604160045260246000fd5b6040526126a683611dca565b81526126b460208401611dca565b602082015260408301356040820152606083013560608201526080830135608082015260a083013560a082015260c083013560c08201528091505092915050565b60006020828403121561270757600080fd5b815160068110610dd557600080fd5b600061010080835261272a8184018961227c565b91505061273a60208301876123fe565b6001600160a01b03851660a08301528360c08301528260e08301529695505050505050565b60a0810161276d82856123fe565b610dd560808301846125ec565b608081016117b082846123fe565b60006020828403121561279a57600080fd5b5051919050565b60c0815260006127b460c083018661227c565b828103602084015284356127c781611db2565b6001600160a01b03168152602085810135908201526127e960408601866121c8565b606060408401526127fe606084018284612233565b9350505050610a1760408301846123fe565b6000806040838503121561282357600080fd5b505080516020909101519092909150565b60a08152600061284760a083018561227c565b9050610dd560208301846123fe56fea2646970667358221220c37ba6c4485eb16b6178756c9b00b9891c4ee952f5591c57ecac8750e9da113164736f6c63430008130033",
-            sourceMap:
-                "412:14182:51:-:0;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;519:100;;;;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;;;;;;;778:25:123;;;766:2;751:18;519:100:51;;;;;;;;8871:628;;;;;;:::i;:::-;;:::i;:::-;;261:31:2;;;;;;;;-1:-1:-1;;;;;1804:55:123;;;1786:74;;1774:2;1759:18;261:31:2;1624:242:123;1158:1566:51;;;;;;:::i;:::-;;:::i;9543:645::-;;;;;;:::i;:::-;;:::i;14094:498::-;;;;;;:::i;:::-;;:::i;:::-;;;3538:14:123;;3531:22;3513:41;;3501:2;3486:18;14094:498:51;3373:187:123;503:163:0;;;;;;:::i;:::-;;:::i;13916:148:51:-;;;;;;:::i;:::-;;:::i;:::-;;;;;;;:::i;1002:112::-;1080:29;;;;;;;;;;;;;;;;1002:112;;;;1080:29;1002:112;:::i;10232:1391::-;;;;;;:::i;:::-;;:::i;13709:163::-;;;;;;:::i;:::-;;:::i;:::-;;;;;;6140:4:123;6182:3;6171:9;6167:19;6159:27;;-1:-1:-1;;;;;6293:2:123;6284:6;6278:13;6274:22;6263:9;6256:41;6365:2;6357:4;6349:6;6345:17;6339:24;6335:33;6328:4;6317:9;6313:20;6306:63;;6425:4;6417:6;6413:17;6407:24;6400:4;6389:9;6385:20;6378:54;6488:4;6480:6;6476:17;6470:24;6463:4;6452:9;6448:20;6441:54;6551:4;6543:6;6539:17;6533:24;6526:4;6515:9;6511:20;6504:54;6614:4;6606:6;6602:17;6596:24;6589:4;6578:9;6574:20;6567:54;6677:4;6669:6;6665:17;6659:24;6652:4;6641:9;6637:20;6630:54;5976:714;;;;;2768:5860:51;;;;;;:::i;:::-;;:::i;664:104::-;;;;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;;;;;;8871:628;8982:18;9003:16;9010:8;9003:6;:16::i;:::-;8982:37;;9025:32;9060:39;9074:8;9084;9094:4;9060:13;:39::i;:::-;9025:74;;9168:1;9106:12;:32;9119:8;:18;;;9106:32;;;;;;;;;;;:58;;;:63;;;;;;;:::i;:::-;;;;-1:-1:-1;;9193:18:51;;;;9175:17;:37;;;;;;;;;;;9213:10;9175:49;;;;;;;:54;;9228:1;;9175:17;:54;;9228:1;;9175:54;:::i;:::-;;;;-1:-1:-1;;9235:27:51;;9366:17;;;;9400:16;;;;;9235:188;;;;;-1:-1:-1;;;;;9235:34:51;;;;;;:188;;9288:10;;9316:8;;9342;;9366:17;;9235:188;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;9477:7;:16;;;9465:10;-1:-1:-1;;;;;9435:59:51;9453:10;9435:59;;;;;;;;;;8976:523;;8871:628;;:::o;1158:1566::-;404:10:0;-1:-1:-1;;;;;426:6:0;404:29;;400:61;;442:19;;;;;;;;;;;;;;400:61;1332:18:51::1;1353:16;1360:8;1353:6;:16::i;:::-;1332:37:::0;-1:-1:-1;1375:32:51::1;1410:45;1428:26;;::::0;::::1;:8:::0;:26:::1;:::i;1410:45::-;1511:18;::::0;::::1;;1461:34;1498:32:::0;;;:12:::1;:32;::::0;;;;;;1604:21:::1;::::0;::::1;::::0;1556:45;;;;;1581:19;;::::1;;1556:45;::::0;::::1;778:25:123::0;1604:21:51;;-1:-1:-1;1498:32:51;1604:21;1556:6:::1;-1:-1:-1::0;;;;;1556:24:51::1;::::0;::::1;::::0;751:18:123;;1556:45:51::1;;;;;;;;;;;;;;;;;::::0;::::1;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;:69;;;;;;:::i;:::-;1541:12;:84;1537:152;;;1642:40;;;;;;;;;;;;;;1537:152;1695:27:::0;;-1:-1:-1;;;;;1695:32:51::1;;1745:17;;::::0;::::1;:8:::0;:17:::1;:::i;:::-;1816;::::0;::::1;::::0;1850:16:::1;::::0;;::::1;::::0;1695:178;;;::::1;::::0;;;;;;-1:-1:-1;;;;;14223:15:123;;;1695:178:51::1;::::0;::::1;14205:34:123::0;1782:18:51::1;::::0;::::1;;14255::123::0;;;14248:34;14318:15;;;;14298:18;;;14291:43;14350:18;;;14343:34;14116:19;;1695:178:51::1;;;;;;;;;;;;;;;;;::::0;::::1;;;;;;;;;;;;::::0;::::1;;;;;;;;;2000:10;1961:8;:19;;;1922:8;:18;;;1885:192;2028:8;2058:12;1885:192;;;;;;;:::i;:::-;;;;;;;;2262:25;2240:18;::::0;::::1;::::0;::::1;;:47;::::0;::::1;;;;;;:::i;:::-;::::0;2236:484:::1;;2319:7;:30;;;2301:15;:48;2297:102;;;2358:41;;;;;;;;;;;;;;2297:102;2428:27;2407:18:::0;;::::1;:48:::0;;;::::1;::::0;::::1;::::0;;2463:34;;;2510:88:::1;::::0;2463:34;;2538:18:::1;::::0;::::1;;::::0;2510:88:::1;::::0;::::1;::::0;::::1;:::i;:::-;;;;;;;;2236:484;;;2629:21:::0;;2615:35;::::1;2611:109;;2660:53;::::0;;;;-1:-1:-1;;;;;2660:6:51::1;:22;::::0;::::1;::::0;:53:::1;::::0;2683:8;;2693:9;;2704:8;;2660:53:::1;;;:::i;:::-;;;;;;;;;;;;;;;;;;::::0;::::1;;;;;;;;;;;;::::0;::::1;;;;;;;;;2611:109;1326:1398;;;1158:1566:::0;;;:::o;9543:645::-;9658:18;9679:16;9686:8;9679:6;:16::i;:::-;9658:37;;9701:32;9736:40;9750:8;9760;9770:5;9736:13;:40::i;:::-;9701:75;;9849:1;9783:12;:32;9796:8;:18;;;9783:32;;;;;;;;;;;:62;;;:67;;;;;;;:::i;:::-;;;;-1:-1:-1;;9878:18:51;;;;9856:41;;;;9913:1;9856:41;;;;;;;;9898:10;9856:53;;;;;;;:58;;9913:1;;9856:53;;:58;;9913:1;;9856:58;:::i;:::-;;;;-1:-1:-1;;9920:27:51;;10051:17;;;;10085:16;;;;;9920:188;;;;;-1:-1:-1;;;;;9920:34:51;;;;;;:188;;9973:10;;10001:8;;10027;;10051:17;;9920:188;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;10166:7;:16;;;10154:10;-1:-1:-1;;;;;10120:63:51;10142:10;10120:63;;;;;;;;;;9652:536;;9543:645;;:::o;14094:498::-;14214:11;14233:32;14268:37;14286:18;;14268:17;:37::i;:::-;14328:27;;14233:72;;-1:-1:-1;;;;;;14320:50:51;;;;;:94;;-1:-1:-1;14382:17:51;;;;-1:-1:-1;;;;;14374:40:51;;;14320:94;:125;;;;-1:-1:-1;14424:16:51;;;;:21;;14320:125;:164;;;;-1:-1:-1;14449:30:51;;;;:35;;14320:164;:203;;;;-1:-1:-1;14488:30:51;;;;:35;;14320:203;:237;;;;-1:-1:-1;14533:19:51;;;;:24;;14320:237;:267;;;;-1:-1:-1;14561:21:51;;;;:26;;14320:267;14311:276;14094:498;-1:-1:-1;;;;14094:498:51:o;503:163:0:-;404:10;-1:-1:-1;;;;;426:6:0;404:29;;400:61;;442:19;;;;;;;;;;;;;;400:61;503:163;;;:::o;13916:148:51:-;13980:33;-1:-1:-1;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;13980:33:51;14035:24;;;;:12;:24;;;;;;;;;14021:38;;;;;;;;;;;;;;;;14035:24;;14021:38;;;;;;;;;;;;;:::i;:::-;;;;;;;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;;;13916:148;-1:-1:-1;;13916:148:51:o;10232:1391::-;10403:18;10425:58;10453:8;10463:9;10474:8;10425:27;:58::i;:::-;10400:83;-1:-1:-1;10489:32:51;;-1:-1:-1;10524:45:51;10542:26;;;;:8;:26;:::i;10524:45::-;10625:18;;;;10575:34;10612:32;;;:12;:32;;;;;10707:19;;;;10674:30;;;;10489:80;;-1:-1:-1;10612:32:51;;10674:52;;10707:19;10674:52;:::i;:::-;10655:15;:71;10651:143;;10743:44;;;;;;;;;;;;;;10651:143;10826:27;10804:18;;;;;;:49;;;;;;;;:::i;:::-;;10800:127;;10870:50;;;;;;;;;;;;;;10800:127;10962:37;;;;11038:41;;;;11090:44;;;11086:112;;11151:40;;;;;;;;;;;;;;11086:112;11225:43;;;;11295:84;;11346:33;11295:84;;;11311:32;11295:84;11274:18;;;;:105;;:18;;:105;;;;;;;;;;;;;;:::i;:::-;;;;;-1:-1:-1;11451:18:51;;;;11391:79;;11439:10;;11419:18;;;;;11391:79;;;;11451:18;;;;;11391:79;:::i;:::-;;;;;;;;11477:6;-1:-1:-1;;;;;11477:26:51;;11511:8;11521:9;11532:8;11542:13;:70;;11586:26;11542:70;;;11558:25;11542:70;11477:141;;;;;;;;;;;;;;;;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;10394:1229;;;;;;10232:1391;;;:::o;13709:163::-;13779:32;-1:-1:-1;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;13779:32:51;13829:38;;;;13840:5;13829:38;:::i;:::-;13819:48;13709:163;-1:-1:-1;;;13709:163:51:o;2768:5860::-;404:10:0;-1:-1:-1;;;;;426:6:0;404:29;;400:61;;442:19;;;;;;;;;;;;;;400:61;2962:32:51::1;2997:45;3015:26;;::::0;::::1;:8:::0;:26:::1;:::i;2997:45::-;3098:18;::::0;::::1;;3048:34;3085:32:::0;;;:12:::1;:32;::::0;;;;;3162;;;;;::::1;::::0;::::1;778:25:123::0;;;2962:80:51;;-1:-1:-1;3085:32:51;3162:6:::1;-1:-1:-1::0;;;;;3162:20:51::1;::::0;::::1;::::0;751:18:123;;3162:32:51::1;;;;;;;;;;;;;;;;;::::0;::::1;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;3123:71;;3200:31;3256:11;:21;;;3242:10;:35:::0;3238:5164:::1;;3370:31;3352:14;:49;;;;;;;;:::i;:::-;::::0;3348:3356:::1;;3586:7;:30;;;3567:15;:49;3563:106;;3625:44;;;;;;;;;;;;;;3563:106;3717:27;3695:18:::0;;::::1;::::0;::::1;;:49;::::0;::::1;;;;;;:::i;:::-;;;:147;;;;3801:11;:41;;;3760:11;:37;;;:82;;3695:147;3680:240;;;3872:37;;;;;;;;;;;;;;3680:240;-1:-1:-1::0;3943:30:51::1;3238:5164;;3348:3356;4010:34;3992:14;:52;;;;;;;;:::i;:::-;::::0;3988:2716:::1;;4234:30;4221:43;;4363:1;4319:11;:41;;;4279:11;:37;;;:81;;;;:::i;:::-;:85;4275:449;;;4378:7;:27;;;-1:-1:-1::0;;;;;4378:50:51::1;;4453:8;4485;4515:7;:17;;;4565:7;:16;;;4659:11;:41;;;4619:11;:37;;;:81;;;;:::i;:::-;4378:335;;;;;;;;;;;;;;;;;;;:::i;:::-;;;;;;;;;;;;;;;;;;::::0;::::1;;;;;;;;;;;;::::0;::::1;;;;;;;;;4275:449;4734:27:::0;;-1:-1:-1;;;;;4734:35:51::1;;4833:17;;::::0;::::1;:8:::0;:17:::1;:::i;:::-;4870;::::0;::::1;::::0;4908:16:::1;::::0;;::::1;::::0;4734:201;;;::::1;::::0;;;;;;-1:-1:-1;;;;;14223:15:123;;;4734:201:51::1;::::0;::::1;14205:34:123::0;4794:18:51::1;::::0;::::1;;14255::123::0;;;14248:34;14318:15;;;;14298:18;;;14291:43;14350:18;;;14343:34;14116:19;;4734:201:51::1;;;;;;;;;;;;;;;;;::::0;::::1;;;;;;;;;;;;::::0;::::1;;;;;;;;;3238:5164;;3988:2716;5119:9;5149:25;5131:14;:43;;;;;;;;:::i;:::-;;5119:55;;5197:4;:75;;5239:33;5197:75;;;5204:32;5197:75;5312:37;::::0;::::1;::::0;5392:41:::1;::::0;::::1;::::0;5184:88;;-1:-1:-1;5312:37:51;5448:26;;;;:52:::1;;;5499:1;5478:18;:22;5448:52;5444:697;;;5514:20;5537:4;:280;;5727:90;5756:18;5776:7;:16;;;5794:22;5727:28;:90::i;:::-;5694:7;:16;;;:123;;;;:::i;:::-;5537:280;;;5589:90;5618:22;5642:7;:16;;;5660:18;5589:28;:90::i;:::-;5556:7;:16;;;:123;;;;:::i;:::-;5514:303;;5830:7;:27;;;-1:-1:-1::0;;;;;5830:50:51::1;;5905:8;5937;5967:7;:17;;;6017:12;6067:4;:50;;6095:22;6067:50;;;6074:18;6067:50;5830:300;;;;;;;;;;;;;;;;;;;:::i;:::-;;;;;;;;;;;;;;;;;;::::0;::::1;;;;;;;;;;;;::::0;::::1;;;;;;;;;5502:639;5444:697;6151:27:::0;;-1:-1:-1;;;;;6151:31:51::1;;6207:18;::::0;::::1;;6245:4:::0;:44:::1;;6272:17;;::::0;::::1;:8:::0;:17:::1;:::i;:::-;6245:44;;;6252:17;::::0;;;::::1;::::0;::::1;;:::i;:::-;6312:4;:44;;6339:17;::::0;;;::::1;::::0;::::1;;:::i;:::-;6312:44;;;6319:17;;::::0;::::1;:8:::0;:17:::1;:::i;:::-;6376;::::0;::::1;::::0;6414:16:::1;::::0;;::::1;::::0;6151:290;;;::::1;::::0;;;;;;::::1;::::0;::::1;19337:25:123::0;;;;-1:-1:-1;;;;;19459:15:123;;;19439:18;;;19432:43;19511:15;;;19491:18;;;19484:43;19563:15;;;;19543:18;;;19536:43;19595:19;;;19588:35;19309:19;;6151:290:51::1;;;;;;;;;;;;;;;;;::::0;::::1;;;;;;;;;;;;::::0;::::1;;;;;;;;;6456:4;6452:244;;;6474:27:::0;;-1:-1:-1;;;;;6474:35:51::1;;6577:17;;::::0;::::1;:8:::0;:17:::1;:::i;:::-;6616;::::0;::::1;::::0;6656:16:::1;::::0;;::::1;::::0;6474:211;;;::::1;::::0;;;;;;-1:-1:-1;;;;;14223:15:123;;;6474:211:51::1;::::0;::::1;14205:34:123::0;6536:18:51::1;::::0;::::1;;14255::123::0;;;14248:34;14318:15;;;;14298:18;;;14291:43;14350:18;;;14343:34;14116:19;;6474:211:51::1;;;;;;;;;;;;;;;;;::::0;::::1;;;;;;;;;;;;::::0;::::1;;;;;;;;;6452:244;4950:1754;;;3238:5164;;;6827:31;6809:14;:49;;;;;;;;:::i;:::-;::::0;6805:1591:::1;;-1:-1:-1::0;7008:30:51::1;6805:1591;;;7075:34;7057:14;:52;;;;;;;;:::i;:::-;::::0;7053:1343:::1;;-1:-1:-1::0;7311:27:51;;7271:30:::1;::::0;-1:-1:-1;;;;;7311:35:51::1;;7410:17;;::::0;::::1;:8:::0;:17:::1;:::i;7053:1343::-;7679:9;7709:25;7691:14;:43;;;;;;;;:::i;:::-;;7679:55;;7757:4;:75;;7799:33;7757:75;;;7764:32;7757:75;7843:27:::0;;7744:88;;-1:-1:-1;;;;;;7843:31:51::1;;7899:18;::::0;::::1;;7937:4:::0;:44:::1;;7964:17;;::::0;::::1;:8:::0;:17:::1;:::i;:::-;7937:44;;;7944:17;::::0;;;::::1;::::0;::::1;;:::i;:::-;8004:4;:44;;8031:17;::::0;;;::::1;::::0;::::1;;:::i;:::-;8004:44;;;8011:17;;::::0;::::1;:8:::0;:17:::1;:::i;:::-;8068;::::0;::::1;::::0;8106:16:::1;::::0;;::::1;::::0;7843:290;;;::::1;::::0;;;;;;::::1;::::0;::::1;19337:25:123::0;;;;-1:-1:-1;;;;;19459:15:123;;;19439:18;;;19432:43;19511:15;;;19491:18;;;19484:43;19563:15;;;;19543:18;;;19536:43;19595:19;;;19588:35;19309:19;;7843:290:51::1;;;;;;;;;;;;;;;;;::::0;::::1;;;;;;;;;;;;::::0;::::1;;;;;;;;;8148:4;8144:244;;;8166:27:::0;;-1:-1:-1;;;;;8166:35:51::1;;8269:17;;::::0;::::1;:8:::0;:17:::1;:::i;:::-;8308;::::0;::::1;::::0;8348:16:::1;::::0;;::::1;::::0;8166:211;;;::::1;::::0;;;;;;-1:-1:-1;;;;;14223:15:123;;;8166:211:51::1;::::0;::::1;14205:34:123::0;8228:18:51::1;::::0;::::1;;14255::123::0;;;14248:34;14318:15;;;;14298:18;;;14291:43;14350:18;;;14343:34;14116:19;;8166:211:51::1;;;;;;;;;;;;;;;;;::::0;::::1;;;;;;;;;;;;::::0;::::1;;;;;;;;;8144:244;7527:869;7053:1343;8408:18;::::0;;::::1;:31:::0;;8429:10;;8408:31;;;::::1;::::0;8429:10;8408:31:::1;::::0;::::1;;;;;;:::i;:::-;;;;;;8498:10;8478:8;:18;;;8450:71;8510:10;8450:71;;;;;;:::i;:::-;;;;;;;;8566:10;8532:91;8588:8;8607:14;8532:91;;;;;;;:::i;:::-;;;;;;;;2956:5672;;;;2768:5860:::0;;;;:::o;1097:133:2:-;1196:29;;;;;1171:11;;1196:12;;:19;;:29;;1216:8;;1196:29;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;1190:35;1097:133;-1:-1:-1;;1097:133:2:o;11906:1573:51:-;12056:32;-1:-1:-1;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;12056:32:51;12096:18;12117:36;12134:8;12144;12117:16;:36::i;:::-;12208:18;;;;12159:33;12195:32;;;:12;:32;;;;;;;;12159:68;;;;;;;;;;;;;;;;12096:57;;-1:-1:-1;12159:33:51;;:68;;12195:32;12159:68;;;;;;;;;;;;;:::i;:::-;;;;;;;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;;12252:21;;12159:68;;-1:-1:-1;12238:35:51;;12234:100;;12290:37;;;;;;;;;;;;;;12234:100;12350:45;12368:26;;;;:8;:26;:::i;12350:45::-;12340:55;;12457:7;:19;;;12424:7;:30;;;:52;;;;:::i;:::-;12406:15;:70;12402:139;;;12493:41;;;;;;;;;;;;;;12402:139;12580:37;;;;12660:41;;;;12708:575;;;;12763:7;:30;;;12737:22;:56;12733:140;;12812:52;;;;;;;;;;;;;;12733:140;12909:26;12884:22;:51;12880:112;;;12944:48;;;;;;;;;;;;;;12880:112;12708:575;;;13047:7;:30;;;13017:26;:60;13013:144;;13096:52;;;;;;;;;;;;;;13013:144;13197:22;13168:26;:51;13164:112;;;13228:48;;;;;;;;;;;;;;13164:112;13311:7;:30;;;13293:15;:48;:104;;;;;13371:26;13345:22;:52;13293:104;13289:186;;;13414:54;;;;;;;;;;;;;;13289:186;12090:1389;;;;11906:1573;;;;;:::o;3265:420:2:-;3448:19;3469:18;3523:12;:40;3564:8;3574:9;3585:8;3523:71;;;;;;;;;;;;;;;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;3605:35;;;;;;;;778:25:123;;;3495:99:2;;-1:-1:-1;3495:99:2;-1:-1:-1;3605:6:2;-1:-1:-1;;;;;3605:23:2;;;;751:18:123;;3605:35:2;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;:40;;3644:1;3605:40;3601:79;;3654:26;;;;;;;;;;;;;;3601:79;3265:420;;;;;;:::o;1564:526:47:-;1680:9;1928:1;1915:11;1911:19;1908:1;1905:26;1902:1;1898:34;1891:42;1878:11;1874:60;1864:116;;1964:1;1961;1954:12;1864:116;-1:-1:-1;2051:9:47;;2047:27;;1564:526::o;2047:310:2:-;2217:49;;;;;2178:18;;2217:12;;:29;;:49;;2247:8;;2257;;2217:49;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;2277:35;;;;;;;;778:25:123;;;2204:62:2;;-1:-1:-1;2277:6:2;-1:-1:-1;;;;;2277:23:2;;;;751:18:123;;2277:35:2;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;:40;;2316:1;2277:40;2273:79;;2326:26;;;;;;;;;;;;;;14:154:123;-1:-1:-1;;;;;93:5:123;89:54;82:5;79:65;69:93;;158:1;155;148:12;69:93;14:154;:::o;173:134::-;241:20;;270:31;241:20;270:31;:::i;:::-;173:134;;;:::o;312:315::-;380:6;388;441:2;429:9;420:7;416:23;412:32;409:52;;;457:1;454;447:12;409:52;493:9;480:23;470:33;;553:2;542:9;538:18;525:32;566:31;591:5;566:31;:::i;:::-;616:5;606:15;;;312:315;;;;;:::o;814:156::-;874:5;919:3;910:6;905:3;901:16;897:26;894:46;;;936:1;933;926:12;894:46;-1:-1:-1;958:6:123;814:156;-1:-1:-1;814:156:123:o;975:::-;1035:5;1080:3;1071:6;1066:3;1062:16;1058:26;1055:46;;;1097:1;1094;1087:12;1136:483;1258:6;1266;1319:3;1307:9;1298:7;1294:23;1290:33;1287:53;;;1336:1;1333;1326:12;1287:53;1376:9;1363:23;1409:18;1401:6;1398:30;1395:50;;;1441:1;1438;1431:12;1395:50;1464:67;1523:7;1514:6;1503:9;1499:22;1464:67;:::i;:::-;1454:77;;;1550:63;1605:7;1600:2;1589:9;1585:18;1550:63;:::i;:::-;1540:73;;1136:483;;;;;:::o;1871:156::-;1932:5;1977:2;1968:6;1963:3;1959:16;1955:25;1952:45;;;1993:1;1990;1983:12;2032:740;2191:6;2199;2207;2260:3;2248:9;2239:7;2235:23;2231:33;2228:53;;;2277:1;2274;2267:12;2228:53;2317:9;2304:23;2346:18;2387:2;2379:6;2376:14;2373:34;;;2403:1;2400;2393:12;2373:34;2426:67;2485:7;2476:6;2465:9;2461:22;2426:67;:::i;:::-;2416:77;;2546:2;2535:9;2531:18;2518:32;2502:48;;2575:2;2565:8;2562:16;2559:36;;;2591:1;2588;2581:12;2559:36;;2614:70;2676:7;2665:8;2654:9;2650:24;2614:70;:::i;:::-;2604:80;;;2703:63;2758:7;2753:2;2742:9;2738:18;2703:63;:::i;:::-;2693:73;;2032:740;;;;;:::o;2777:591::-;2847:6;2855;2908:2;2896:9;2887:7;2883:23;2879:32;2876:52;;;2924:1;2921;2914:12;2876:52;2964:9;2951:23;2993:18;3034:2;3026:6;3023:14;3020:34;;;3050:1;3047;3040:12;3020:34;3088:6;3077:9;3073:22;3063:32;;3133:7;3126:4;3122:2;3118:13;3114:27;3104:55;;3155:1;3152;3145:12;3104:55;3195:2;3182:16;3221:2;3213:6;3210:14;3207:34;;;3237:1;3234;3227:12;3207:34;3282:7;3277:2;3268:6;3264:2;3260:15;3256:24;3253:37;3250:57;;;3303:1;3300;3293:12;3250:57;3334:2;3326:11;;;;;3356:6;;-1:-1:-1;2777:591:123;;-1:-1:-1;;;;2777:591:123:o;3565:748::-;3697:6;3705;3713;3766:2;3754:9;3745:7;3741:23;3737:32;3734:52;;;3782:1;3779;3772:12;3734:52;3822:9;3809:23;3851:18;3892:2;3884:6;3881:14;3878:34;;;3908:1;3905;3898:12;3878:34;3931:67;3990:7;3981:6;3970:9;3966:22;3931:67;:::i;:::-;3921:77;;4051:2;4040:9;4036:18;4023:32;4007:48;;4080:2;4070:8;4067:16;4064:36;;;4096:1;4093;4086:12;4064:36;;4119:70;4181:7;4170:8;4159:9;4155:24;4119:70;:::i;:::-;4109:80;;;4239:2;4228:9;4224:18;4211:32;4252:31;4277:5;4252:31;:::i;:::-;4302:5;4292:15;;;3565:748;;;;;:::o;4318:180::-;4377:6;4430:2;4418:9;4409:7;4405:23;4401:32;4398:52;;;4446:1;4443;4436:12;4398:52;-1:-1:-1;4469:23:123;;4318:180;-1:-1:-1;4318:180:123:o;4503:184::-;4555:77;4552:1;4545:88;4652:4;4649:1;4642:15;4676:4;4673:1;4666:15;4692:151;4784:1;4777:5;4774:12;4764:46;;4790:18;;:::i;:::-;4819;;4692:151::o;4848:511::-;5079:13;;5061:32;;5140:4;5128:17;;;5122:24;5048:3;5033:19;;;5155:72;;5206:20;;5122:24;5155:72;:::i;:::-;;5283:4;5275:6;5271:17;5265:24;5258:4;5247:9;5243:20;5236:54;5346:4;5338:6;5334:17;5328:24;5321:4;5310:9;5306:20;5299:54;4848:511;;;;:::o;5364:607::-;5476:4;5505:2;5534;5523:9;5516:21;5566:6;5560:13;5609:6;5604:2;5593:9;5589:18;5582:34;5634:1;5644:140;5658:6;5655:1;5652:13;5644:140;;;5753:14;;;5749:23;;5743:30;5719:17;;;5738:2;5715:26;5708:66;5673:10;;5644:140;;;5648:3;5833:1;5828:2;5819:6;5808:9;5804:22;5800:31;5793:42;5962:2;5892:66;5887:2;5879:6;5875:15;5871:88;5860:9;5856:104;5852:113;5844:121;;;;5364:607;;;;:::o;6695:808::-;6863:6;6871;6879;6887;6940:3;6928:9;6919:7;6915:23;6911:33;6908:53;;;6957:1;6954;6947:12;6908:53;6993:9;6980:23;6970:33;;7054:2;7043:9;7039:18;7026:32;7077:18;7118:2;7110:6;7107:14;7104:34;;;7134:1;7131;7124:12;7104:34;7157:67;7216:7;7207:6;7196:9;7192:22;7157:67;:::i;:::-;7147:77;;7277:2;7266:9;7262:18;7249:32;7233:48;;7306:2;7296:8;7293:16;7290:36;;;7322:1;7319;7312:12;7290:36;;7345:70;7407:7;7396:8;7385:9;7381:24;7345:70;:::i;:::-;7335:80;;;7434:63;7489:7;7484:2;7473:9;7469:18;7434:63;:::i;:::-;7424:73;;6695:808;;;;;;;:::o;7508:279::-;7573:9;;;7594:10;;;7591:190;;;7637:77;7634:1;7627:88;7738:4;7735:1;7728:15;7766:4;7763:1;7756:15;7924:179;7991:20;;8051:26;8040:38;;8030:49;;8020:77;;8093:1;8090;8083:12;8223:559;8281:5;8288:6;8348:3;8335:17;8430:66;8419:8;8403:14;8399:29;8395:102;8375:18;8371:127;8361:155;;8512:1;8509;8502:12;8361:155;8540:33;;8644:4;8631:18;;;-1:-1:-1;8592:21:123;;-1:-1:-1;8672:18:123;8661:30;;8658:50;;;8704:1;8701;8694:12;8658:50;8751:6;8735:14;8731:27;8724:5;8720:39;8717:59;;;8772:1;8769;8762:12;8717:59;8223:559;;;;;:::o;8787:325::-;8875:6;8870:3;8863:19;8927:6;8920:5;8913:4;8908:3;8904:14;8891:43;;8979:1;8972:4;8963:6;8958:3;8954:16;8950:27;8943:38;8845:3;9101:4;9031:66;9026:2;9018:6;9014:15;9010:88;9005:3;9001:98;8997:109;8990:116;;8787:325;;;;:::o;9117:2164::-;9176:3;9204:6;9219:48;9263:3;9237:24;9255:5;9237:24;:::i;:::-;8184:26;8173:38;8161:51;;8108:110;9219:48;9296:36;9326:4;9319:5;9315:16;9296:36;:::i;:::-;-1:-1:-1;;;;;7858:54:123;9383:4;9374:14;;7846:67;9420:36;9450:4;9439:16;;9420:36;:::i;:::-;-1:-1:-1;;;;;7858:54:123;9509:4;9500:14;;7846:67;9546:36;9576:4;9565:16;;9546:36;:::i;:::-;-1:-1:-1;;;;;7858:54:123;9635:4;9626:14;;7846:67;9672:36;9702:4;9691:16;;9672:36;:::i;:::-;-1:-1:-1;;;;;7858:54:123;9761:4;9752:14;;7846:67;9798:36;9828:4;9817:16;;9798:36;:::i;:::-;-1:-1:-1;;;;;7858:54:123;9887:4;9878:14;;7846:67;9924:36;9954:4;9943:16;;9924:36;:::i;:::-;-1:-1:-1;;;;;7858:54:123;10013:4;10004:14;;7846:67;10064:55;10113:4;10102:16;;10106:5;10064:55;:::i;:::-;10151:2;10144:4;10139:3;10135:14;10128:26;10175:69;10240:2;10235:3;10231:12;10217;10201:14;10175:69;:::i;:::-;10163:81;;;;10263:6;10316:53;10365:2;10358:5;10354:14;10347:5;10316:53;:::i;:::-;10409:3;10403:4;10399:14;10394:2;10389:3;10385:12;10378:36;10437:63;10495:4;10479:14;10463;10437:63;:::i;:::-;10423:77;;;;;10519:6;10572:53;10621:2;10614:5;10610:14;10603:5;10572:53;:::i;:::-;10667:3;10659:6;10655:16;10650:2;10645:3;10641:12;10634:38;10695:65;10753:6;10737:14;10721;10695:65;:::i;:::-;10681:79;;;;;10779:6;10832:53;10881:2;10874:5;10870:14;10863:5;10832:53;:::i;:::-;10927:3;10919:6;10915:16;10910:2;10905:3;10901:12;10894:38;10955:65;11013:6;10997:14;10981;10955:65;:::i;:::-;10941:79;;;;;11039:6;11093:53;11142:2;11135:5;11131:14;11124:5;11093:53;:::i;:::-;11188:3;11180:6;11176:16;11171:2;11166:3;11162:12;11155:38;11209:66;11268:6;11252:14;11235:15;11209:66;:::i;:::-;11202:73;9117:2164;-1:-1:-1;;;;;;;9117:2164:123:o;11286:522::-;11384:5;11371:19;11399:33;11424:7;11399:33;:::i;:::-;-1:-1:-1;;;;;11514:16:123;;;11502:29;;11579:4;11568:16;;11555:30;;11594:33;11555:30;11594:33;:::i;:::-;11659:16;11652:4;11643:14;;11636:40;11732:4;11721:16;;;11708:30;11692:14;;;11685:54;11795:4;11784:16;;;11771:30;11755:14;;11748:54;11286:522::o;11813:751::-;12136:4;12165:3;-1:-1:-1;;;;;12268:2:123;12260:6;12256:15;12245:9;12238:34;12308:2;12303;12292:9;12288:18;12281:30;12328:62;12386:2;12375:9;12371:18;12363:6;12328:62;:::i;:::-;12320:70;;12399:62;12457:2;12446:9;12442:18;12434:6;12399:62;:::i;:::-;12510:2;12502:6;12498:15;12492:3;12481:9;12477:19;12470:44;;;12551:6;12545:3;12534:9;12530:19;12523:35;11813:751;;;;;;;;:::o;12569:580::-;12646:4;12652:6;12712:11;12699:25;12802:66;12791:8;12775:14;12771:29;12767:102;12747:18;12743:127;12733:155;;12884:1;12881;12874:12;12733:155;12911:33;;12963:20;;;-1:-1:-1;13006:18:123;12995:30;;12992:50;;;13038:1;13035;13028:12;12992:50;13071:4;13059:17;;-1:-1:-1;13102:14:123;13098:27;;;13088:38;;13085:58;;;13139:1;13136;13129:12;13336:305;13406:6;13459:2;13447:9;13438:7;13434:23;13430:32;13427:52;;;13475:1;13472;13465:12;13427:52;13507:9;13501:16;13557:34;13550:5;13546:46;13539:5;13536:57;13526:85;;13607:1;13604;13597:12;13646:247;13705:6;13758:2;13746:9;13737:7;13733:23;13729:32;13726:52;;;13774:1;13771;13764:12;13726:52;13813:9;13800:23;13832:31;13857:5;13832:31;:::i;14388:330::-;14602:3;14587:19;;14615:53;14591:9;14650:6;14615:53;:::i;:::-;14705:6;14699:3;14688:9;14684:19;14677:35;14388:330;;;;;:::o;14723:231::-;14881:2;14866:18;;14893:55;14870:9;14930:6;14893:55;:::i;14959:521::-;15019:3;15065:5;15052:19;15080:33;15105:7;15080:33;:::i;:::-;-1:-1:-1;;;;;15134:56:123;15122:69;;15247:4;15236:16;;;15223:30;15207:14;;;15200:54;15297:55;15346:4;15335:16;;15240:5;15297:55;:::i;:::-;15384:4;15377;15372:3;15368:14;15361:28;15405:69;15468:4;15463:3;15459:14;15445:12;15431;15405:69;:::i;:::-;15398:76;14959:521;-1:-1:-1;;;;;14959:521:123:o;15485:637::-;15828:3;15817:9;15810:22;15791:4;15855:63;15913:3;15902:9;15898:19;15890:6;15855:63;:::i;:::-;15966:9;15958:6;15954:22;15949:2;15938:9;15934:18;15927:50;15994:51;16038:6;16030;15994:51;:::i;:::-;15986:59;;;16054:62;16112:2;16101:9;16097:18;16089:6;16054:62;:::i;16127:144::-;16212:1;16205:5;16202:12;16192:46;;16218:18;;:::i;16276:748::-;16663:3;16652:9;16645:22;16626:4;16690:63;16748:3;16737:9;16733:19;16725:6;16690:63;:::i;:::-;16801:9;16793:6;16789:22;16784:2;16773:9;16769:18;16762:50;16829:51;16873:6;16865;16829:51;:::i;:::-;16821:59;;;16889:62;16947:2;16936:9;16932:18;16924:6;16889:62;:::i;:::-;16960:58;17013:3;17002:9;16998:19;16990:6;16960:58;:::i;17029:1019::-;17124:6;17177:3;17165:9;17156:7;17152:23;17148:33;17145:53;;;17194:1;17191;17184:12;17145:53;17227:2;17221:9;17269:3;17261:6;17257:16;17339:6;17327:10;17324:22;17303:18;17291:10;17288:34;17285:62;17282:242;;;17380:77;17377:1;17370:88;17481:4;17478:1;17471:15;17509:4;17506:1;17499:15;17282:242;17540:2;17533:22;17579:29;17598:9;17579:29;:::i;:::-;17571:6;17564:45;17642:38;17676:2;17665:9;17661:18;17642:38;:::i;:::-;17637:2;17629:6;17625:15;17618:63;17742:2;17731:9;17727:18;17714:32;17709:2;17701:6;17697:15;17690:57;17808:2;17797:9;17793:18;17780:32;17775:2;17767:6;17763:15;17756:57;17875:3;17864:9;17860:19;17847:33;17841:3;17833:6;17829:16;17822:59;17943:3;17932:9;17928:19;17915:33;17909:3;17901:6;17897:16;17890:59;18011:3;18000:9;17996:19;17983:33;17977:3;17969:6;17965:16;17958:59;18036:6;18026:16;;;17029:1019;;;;:::o;18053:278::-;18141:6;18194:2;18182:9;18173:7;18169:23;18165:32;18162:52;;;18210:1;18207;18200:12;18162:52;18242:9;18236:16;18281:1;18274:5;18271:12;18261:40;;18297:1;18294;18287:12;18336:722;18659:4;18688:3;18718:2;18707:9;18700:21;18738:62;18796:2;18785:9;18781:18;18773:6;18738:62;:::i;:::-;18730:70;;;18809:62;18867:2;18856:9;18852:18;18844:6;18809:62;:::i;:::-;-1:-1:-1;;;;;18912:6:123;18908:55;18902:3;18891:9;18887:19;18880:84;19001:6;18995:3;18984:9;18980:19;18973:35;19045:6;19039:3;19028:9;19024:19;19017:35;18336:722;;;;;;;;:::o;19634:369::-;19864:3;19849:19;;19877:53;19853:9;19912:6;19877:53;:::i;:::-;19939:58;19992:3;19981:9;19977:19;19969:6;19939:58;:::i;20008:266::-;20202:3;20187:19;;20215:53;20191:9;20250:6;20215:53;:::i;20279:184::-;20349:6;20402:2;20390:9;20381:7;20377:23;20373:32;20370:52;;;20418:1;20415;20408:12;20370:52;-1:-1:-1;20441:16:123;;20279:184;-1:-1:-1;20279:184:123:o;20468:1032::-;20819:3;20808:9;20801:22;20782:4;20846:63;20904:3;20893:9;20889:19;20881:6;20846:63;:::i;:::-;20957:9;20949:6;20945:22;20940:2;20929:9;20925:18;20918:50;21003:6;20990:20;21019:31;21044:5;21019:31;:::i;:::-;-1:-1:-1;;;;;21074:54:123;21059:70;;21187:2;21175:15;;;21162:29;21145:15;;;21138:54;21235:57;21286:4;21274:17;;21179:6;21235:57;:::i;:::-;21327:4;21320;21312:6;21308:17;21301:31;21349:72;21415:4;21407:6;21403:17;21389:12;21375;21349:72;:::i;:::-;21341:80;;;;;21430:64;21488:4;21477:9;21473:20;21465:6;21430:64;:::i;21505:245::-;21584:6;21592;21645:2;21633:9;21624:7;21620:23;21616:32;21613:52;;;21661:1;21658;21651:12;21613:52;-1:-1:-1;;21684:16:123;;21740:2;21725:18;;;21719:25;21684:16;;21719:25;;-1:-1:-1;21505:245:123:o;21755:430::-;22024:3;22013:9;22006:22;21987:4;22045:63;22103:3;22092:9;22088:19;22080:6;22045:63;:::i;:::-;22037:71;;22117:62;22175:2;22164:9;22160:18;22152:6;22117:62;:::i",
-            linkReferences: {
-                "node_modules/@defi-wonderland/prophet-core/solidity/libraries/ValidatorLib.sol": {
-                    ValidatorLib: [
-                        { start: 5959, length: 20 },
-                        { start: 6781, length: 20 },
-                        { start: 7255, length: 20 },
-                    ],
-                },
-            },
-            immutableReferences: {
-                "1406": [
-                    { start: 313, length: 32 },
-                    { start: 1099, length: 32 },
-                    { start: 1297, length: 32 },
-                    { start: 2006, length: 32 },
-                    { start: 2602, length: 32 },
-                    { start: 3292, length: 32 },
-                    { start: 3559, length: 32 },
-                    { start: 3735, length: 32 },
-                    { start: 6954, length: 32 },
-                    { start: 7412, length: 32 },
-                ],
-            },
-        },
-        methodIdentifiers: {
-            "ORACLE()": "38013f02",
-            "decodeRequestData(bytes)": "d12481a4",
-            "disputeResponse((uint96,address,address,address,address,address,address,bytes,bytes,bytes,bytes,bytes),(address,bytes32,bytes),(address,address,bytes32,bytes32))":
-                "3974363f",
-            "finalizeRequest((uint96,address,address,address,address,address,address,bytes,bytes,bytes,bytes,bytes),(address,bytes32,bytes),address)":
-                "6ec18b8c",
-            "getEscalation(bytes32)": "7068639f",
-            "moduleName()": "93f0899a",
-            "onDisputeStatusChange(bytes32,(uint96,address,address,address,address,address,address,bytes,bytes,bytes,bytes,bytes),(address,bytes32,bytes),(address,address,bytes32,bytes32))":
-                "d58eaf4a",
-            "pledgeAgainstDispute((uint96,address,address,address,address,address,address,bytes,bytes,bytes,bytes,bytes),(address,address,bytes32,bytes32))":
-                "57bf0e3d",
-            "pledgeForDispute((uint96,address,address,address,address,address,address,bytes,bytes,bytes,bytes,bytes),(address,address,bytes32,bytes32))":
-                "08856368",
-            "pledgesAgainstDispute(bytes32,address)": "ef940cef",
-            "pledgesForDispute(bytes32,address)": "076404dc",
-            "settleBondEscalation((uint96,address,address,address,address,address,address,bytes,bytes,bytes,bytes,bytes),(address,bytes32,bytes),(address,address,bytes32,bytes32))":
-                "a93d61c3",
-            "validateParameters(bytes)": "6974f58e",
-        },
-        rawMetadata:
-            '{"compiler":{"version":"0.8.19+commit.7dd6d404"},"language":"Solidity","output":{"abi":[{"inputs":[{"internalType":"contract IOracle","name":"_oracle","type":"address"}],"stateMutability":"nonpayable","type":"constructor"},{"inputs":[],"name":"BondEscalationModule_BondEscalationCantBeSettled","type":"error"},{"inputs":[],"name":"BondEscalationModule_BondEscalationNotOver","type":"error"},{"inputs":[],"name":"BondEscalationModule_BondEscalationOver","type":"error"},{"inputs":[],"name":"BondEscalationModule_CanOnlySurpassByOnePledge","type":"error"},{"inputs":[],"name":"BondEscalationModule_CannotBreakTieDuringTyingBuffer","type":"error"},{"inputs":[],"name":"BondEscalationModule_DisputeDoesNotExist","type":"error"},{"inputs":[],"name":"BondEscalationModule_DisputeWindowOver","type":"error"},{"inputs":[],"name":"BondEscalationModule_InvalidDispute","type":"error"},{"inputs":[],"name":"BondEscalationModule_InvalidEscalationParameters","type":"error"},{"inputs":[],"name":"BondEscalationModule_MaxNumberOfEscalationsReached","type":"error"},{"inputs":[],"name":"BondEscalationModule_NotEscalatable","type":"error"},{"inputs":[],"name":"BondEscalationModule_ShouldBeEscalated","type":"error"},{"inputs":[],"name":"BondEscalationModule_ZeroValue","type":"error"},{"inputs":[],"name":"Module_OnlyOracle","type":"error"},{"inputs":[],"name":"Validator_InvalidDispute","type":"error"},{"inputs":[],"name":"Validator_InvalidResponse","type":"error"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"bytes32","name":"_requestId","type":"bytes32"},{"indexed":true,"internalType":"bytes32","name":"_disputeId","type":"bytes32"},{"indexed":false,"internalType":"enum IBondEscalationModule.BondEscalationStatus","name":"_status","type":"uint8"}],"name":"BondEscalationStatusUpdated","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"bytes32","name":"_disputeId","type":"bytes32"},{"components":[{"internalType":"address","name":"disputer","type":"address"},{"internalType":"address","name":"proposer","type":"address"},{"internalType":"bytes32","name":"responseId","type":"bytes32"},{"internalType":"bytes32","name":"requestId","type":"bytes32"}],"indexed":false,"internalType":"struct IOracle.Dispute","name":"_dispute","type":"tuple"},{"indexed":false,"internalType":"enum IOracle.DisputeStatus","name":"_status","type":"uint8"}],"name":"DisputeStatusChanged","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"bytes32","name":"_disputeId","type":"bytes32"},{"indexed":true,"internalType":"address","name":"_pledger","type":"address"},{"indexed":true,"internalType":"uint256","name":"_amount","type":"uint256"}],"name":"PledgedAgainstDispute","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"bytes32","name":"_disputeId","type":"bytes32"},{"indexed":true,"internalType":"address","name":"_pledger","type":"address"},{"indexed":true,"internalType":"uint256","name":"_amount","type":"uint256"}],"name":"PledgedForDispute","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"bytes32","name":"_requestId","type":"bytes32"},{"components":[{"internalType":"address","name":"proposer","type":"address"},{"internalType":"bytes32","name":"requestId","type":"bytes32"},{"internalType":"bytes","name":"response","type":"bytes"}],"indexed":false,"internalType":"struct IOracle.Response","name":"_response","type":"tuple"},{"indexed":false,"internalType":"address","name":"_finalizer","type":"address"}],"name":"RequestFinalized","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"bytes32","name":"_requestId","type":"bytes32"},{"indexed":true,"internalType":"bytes32","name":"_responseId","type":"bytes32"},{"indexed":true,"internalType":"bytes32","name":"_disputeId","type":"bytes32"},{"components":[{"internalType":"address","name":"disputer","type":"address"},{"internalType":"address","name":"proposer","type":"address"},{"internalType":"bytes32","name":"responseId","type":"bytes32"},{"internalType":"bytes32","name":"requestId","type":"bytes32"}],"indexed":false,"internalType":"struct IOracle.Dispute","name":"_dispute","type":"tuple"},{"indexed":false,"internalType":"uint256","name":"_blockNumber","type":"uint256"}],"name":"ResponseDisputed","type":"event"},{"inputs":[],"name":"ORACLE","outputs":[{"internalType":"contract IOracle","name":"","type":"address"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"bytes","name":"_data","type":"bytes"}],"name":"decodeRequestData","outputs":[{"components":[{"internalType":"contract IBondEscalationAccounting","name":"accountingExtension","type":"address"},{"internalType":"contract IERC20","name":"bondToken","type":"address"},{"internalType":"uint256","name":"bondSize","type":"uint256"},{"internalType":"uint256","name":"maxNumberOfEscalations","type":"uint256"},{"internalType":"uint256","name":"bondEscalationDeadline","type":"uint256"},{"internalType":"uint256","name":"tyingBuffer","type":"uint256"},{"internalType":"uint256","name":"disputeWindow","type":"uint256"}],"internalType":"struct IBondEscalationModule.RequestParameters","name":"_params","type":"tuple"}],"stateMutability":"pure","type":"function"},{"inputs":[{"components":[{"internalType":"uint96","name":"nonce","type":"uint96"},{"internalType":"address","name":"requester","type":"address"},{"internalType":"address","name":"requestModule","type":"address"},{"internalType":"address","name":"responseModule","type":"address"},{"internalType":"address","name":"disputeModule","type":"address"},{"internalType":"address","name":"resolutionModule","type":"address"},{"internalType":"address","name":"finalityModule","type":"address"},{"internalType":"bytes","name":"requestModuleData","type":"bytes"},{"internalType":"bytes","name":"responseModuleData","type":"bytes"},{"internalType":"bytes","name":"disputeModuleData","type":"bytes"},{"internalType":"bytes","name":"resolutionModuleData","type":"bytes"},{"internalType":"bytes","name":"finalityModuleData","type":"bytes"}],"internalType":"struct IOracle.Request","name":"_request","type":"tuple"},{"components":[{"internalType":"address","name":"proposer","type":"address"},{"internalType":"bytes32","name":"requestId","type":"bytes32"},{"internalType":"bytes","name":"response","type":"bytes"}],"internalType":"struct IOracle.Response","name":"_response","type":"tuple"},{"components":[{"internalType":"address","name":"disputer","type":"address"},{"internalType":"address","name":"proposer","type":"address"},{"internalType":"bytes32","name":"responseId","type":"bytes32"},{"internalType":"bytes32","name":"requestId","type":"bytes32"}],"internalType":"struct IOracle.Dispute","name":"_dispute","type":"tuple"}],"name":"disputeResponse","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"components":[{"internalType":"uint96","name":"nonce","type":"uint96"},{"internalType":"address","name":"requester","type":"address"},{"internalType":"address","name":"requestModule","type":"address"},{"internalType":"address","name":"responseModule","type":"address"},{"internalType":"address","name":"disputeModule","type":"address"},{"internalType":"address","name":"resolutionModule","type":"address"},{"internalType":"address","name":"finalityModule","type":"address"},{"internalType":"bytes","name":"requestModuleData","type":"bytes"},{"internalType":"bytes","name":"responseModuleData","type":"bytes"},{"internalType":"bytes","name":"disputeModuleData","type":"bytes"},{"internalType":"bytes","name":"resolutionModuleData","type":"bytes"},{"internalType":"bytes","name":"finalityModuleData","type":"bytes"}],"internalType":"struct IOracle.Request","name":"_request","type":"tuple"},{"components":[{"internalType":"address","name":"proposer","type":"address"},{"internalType":"bytes32","name":"requestId","type":"bytes32"},{"internalType":"bytes","name":"response","type":"bytes"}],"internalType":"struct IOracle.Response","name":"_response","type":"tuple"},{"internalType":"address","name":"_finalizer","type":"address"}],"name":"finalizeRequest","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"bytes32","name":"_requestId","type":"bytes32"}],"name":"getEscalation","outputs":[{"components":[{"internalType":"bytes32","name":"disputeId","type":"bytes32"},{"internalType":"enum IBondEscalationModule.BondEscalationStatus","name":"status","type":"uint8"},{"internalType":"uint256","name":"amountOfPledgesForDispute","type":"uint256"},{"internalType":"uint256","name":"amountOfPledgesAgainstDispute","type":"uint256"}],"internalType":"struct IBondEscalationModule.BondEscalation","name":"_escalation","type":"tuple"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"moduleName","outputs":[{"internalType":"string","name":"_moduleName","type":"string"}],"stateMutability":"pure","type":"function"},{"inputs":[{"internalType":"bytes32","name":"_disputeId","type":"bytes32"},{"components":[{"internalType":"uint96","name":"nonce","type":"uint96"},{"internalType":"address","name":"requester","type":"address"},{"internalType":"address","name":"requestModule","type":"address"},{"internalType":"address","name":"responseModule","type":"address"},{"internalType":"address","name":"disputeModule","type":"address"},{"internalType":"address","name":"resolutionModule","type":"address"},{"internalType":"address","name":"finalityModule","type":"address"},{"internalType":"bytes","name":"requestModuleData","type":"bytes"},{"internalType":"bytes","name":"responseModuleData","type":"bytes"},{"internalType":"bytes","name":"disputeModuleData","type":"bytes"},{"internalType":"bytes","name":"resolutionModuleData","type":"bytes"},{"internalType":"bytes","name":"finalityModuleData","type":"bytes"}],"internalType":"struct IOracle.Request","name":"_request","type":"tuple"},{"components":[{"internalType":"address","name":"proposer","type":"address"},{"internalType":"bytes32","name":"requestId","type":"bytes32"},{"internalType":"bytes","name":"response","type":"bytes"}],"internalType":"struct IOracle.Response","name":"","type":"tuple"},{"components":[{"internalType":"address","name":"disputer","type":"address"},{"internalType":"address","name":"proposer","type":"address"},{"internalType":"bytes32","name":"responseId","type":"bytes32"},{"internalType":"bytes32","name":"requestId","type":"bytes32"}],"internalType":"struct IOracle.Dispute","name":"_dispute","type":"tuple"}],"name":"onDisputeStatusChange","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"components":[{"internalType":"uint96","name":"nonce","type":"uint96"},{"internalType":"address","name":"requester","type":"address"},{"internalType":"address","name":"requestModule","type":"address"},{"internalType":"address","name":"responseModule","type":"address"},{"internalType":"address","name":"disputeModule","type":"address"},{"internalType":"address","name":"resolutionModule","type":"address"},{"internalType":"address","name":"finalityModule","type":"address"},{"internalType":"bytes","name":"requestModuleData","type":"bytes"},{"internalType":"bytes","name":"responseModuleData","type":"bytes"},{"internalType":"bytes","name":"disputeModuleData","type":"bytes"},{"internalType":"bytes","name":"resolutionModuleData","type":"bytes"},{"internalType":"bytes","name":"finalityModuleData","type":"bytes"}],"internalType":"struct IOracle.Request","name":"_request","type":"tuple"},{"components":[{"internalType":"address","name":"disputer","type":"address"},{"internalType":"address","name":"proposer","type":"address"},{"internalType":"bytes32","name":"responseId","type":"bytes32"},{"internalType":"bytes32","name":"requestId","type":"bytes32"}],"internalType":"struct IOracle.Dispute","name":"_dispute","type":"tuple"}],"name":"pledgeAgainstDispute","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"components":[{"internalType":"uint96","name":"nonce","type":"uint96"},{"internalType":"address","name":"requester","type":"address"},{"internalType":"address","name":"requestModule","type":"address"},{"internalType":"address","name":"responseModule","type":"address"},{"internalType":"address","name":"disputeModule","type":"address"},{"internalType":"address","name":"resolutionModule","type":"address"},{"internalType":"address","name":"finalityModule","type":"address"},{"internalType":"bytes","name":"requestModuleData","type":"bytes"},{"internalType":"bytes","name":"responseModuleData","type":"bytes"},{"internalType":"bytes","name":"disputeModuleData","type":"bytes"},{"internalType":"bytes","name":"resolutionModuleData","type":"bytes"},{"internalType":"bytes","name":"finalityModuleData","type":"bytes"}],"internalType":"struct IOracle.Request","name":"_request","type":"tuple"},{"components":[{"internalType":"address","name":"disputer","type":"address"},{"internalType":"address","name":"proposer","type":"address"},{"internalType":"bytes32","name":"responseId","type":"bytes32"},{"internalType":"bytes32","name":"requestId","type":"bytes32"}],"internalType":"struct IOracle.Dispute","name":"_dispute","type":"tuple"}],"name":"pledgeForDispute","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"bytes32","name":"_requestId","type":"bytes32"},{"internalType":"address","name":"_pledger","type":"address"}],"name":"pledgesAgainstDispute","outputs":[{"internalType":"uint256","name":"pledges","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"bytes32","name":"_requestId","type":"bytes32"},{"internalType":"address","name":"_pledger","type":"address"}],"name":"pledgesForDispute","outputs":[{"internalType":"uint256","name":"pledges","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[{"components":[{"internalType":"uint96","name":"nonce","type":"uint96"},{"internalType":"address","name":"requester","type":"address"},{"internalType":"address","name":"requestModule","type":"address"},{"internalType":"address","name":"responseModule","type":"address"},{"internalType":"address","name":"disputeModule","type":"address"},{"internalType":"address","name":"resolutionModule","type":"address"},{"internalType":"address","name":"finalityModule","type":"address"},{"internalType":"bytes","name":"requestModuleData","type":"bytes"},{"internalType":"bytes","name":"responseModuleData","type":"bytes"},{"internalType":"bytes","name":"disputeModuleData","type":"bytes"},{"internalType":"bytes","name":"resolutionModuleData","type":"bytes"},{"internalType":"bytes","name":"finalityModuleData","type":"bytes"}],"internalType":"struct IOracle.Request","name":"_request","type":"tuple"},{"components":[{"internalType":"address","name":"proposer","type":"address"},{"internalType":"bytes32","name":"requestId","type":"bytes32"},{"internalType":"bytes","name":"response","type":"bytes"}],"internalType":"struct IOracle.Response","name":"_response","type":"tuple"},{"components":[{"internalType":"address","name":"disputer","type":"address"},{"internalType":"address","name":"proposer","type":"address"},{"internalType":"bytes32","name":"responseId","type":"bytes32"},{"internalType":"bytes32","name":"requestId","type":"bytes32"}],"internalType":"struct IOracle.Dispute","name":"_dispute","type":"tuple"}],"name":"settleBondEscalation","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"bytes","name":"_encodedParameters","type":"bytes"}],"name":"validateParameters","outputs":[{"internalType":"bool","name":"_valid","type":"bool"}],"stateMutability":"pure","type":"function"}],"devdoc":{"events":{"BondEscalationStatusUpdated(bytes32,bytes32,uint8)":{"params":{"_disputeId":"The id of the dispute going through the bond escalation mechanism.","_requestId":"The id of the request associated with the bond escalation mechanism.","_status":"The new status."}},"DisputeStatusChanged(bytes32,(address,address,bytes32,bytes32),uint8)":{"params":{"_dispute":"The dispute","_disputeId":"The id of the dispute","_status":"The new status of the dispute"}},"PledgedAgainstDispute(bytes32,address,uint256)":{"params":{"_amount":"The amount pledged.","_disputeId":"The id of the dispute the pledger is pledging against.","_pledger":"The address of the pledger."}},"PledgedForDispute(bytes32,address,uint256)":{"params":{"_amount":"The amount pledged.","_disputeId":"The id of the dispute the pledger is pledging in favor of.","_pledger":"The address of the pledger."}},"RequestFinalized(bytes32,(address,bytes32,bytes),address)":{"params":{"_finalizer":"The address that initiated the finalization","_requestId":"The id of the request that was finalized","_response":"The final response"}},"ResponseDisputed(bytes32,bytes32,bytes32,(address,address,bytes32,bytes32),uint256)":{"params":{"_blockNumber":"The current block number","_dispute":"The dispute that is being created","_disputeId":"The id of the dispute","_responseId":"The id of the response disputed"}}},"kind":"dev","methods":{"decodeRequestData(bytes)":{"params":{"_data":"The encoded request parameters"},"returns":{"_params":"The struct containing the parameters for the request"}},"disputeResponse((uint96,address,address,address,address,address,address,bytes,bytes,bytes,bytes,bytes),(address,bytes32,bytes),(address,address,bytes32,bytes32))":{"details":"If this is the first dispute of the request and the bond escalation window is not over,      it will start the bond escalation process. This function must be called through the Oracle.","params":{"_dispute":"The dispute created by the oracle.","_request":"The request data.","_response":"The response being disputed."}},"finalizeRequest((uint96,address,address,address,address,address,address,bytes,bytes,bytes,bytes,bytes),(address,bytes32,bytes),address)":{"params":{"_finalizer":"The address that initiated the finalization","_request":"The request being finalized","_response":"The final response"}},"getEscalation(bytes32)":{"params":{"_requestId":"The id of the request to get its escalation data."},"returns":{"_escalation":"The struct containing the escalation data."}},"moduleName()":{"returns":{"_moduleName":"The name of the module."}},"onDisputeStatusChange(bytes32,(uint96,address,address,address,address,address,address,bytes,bytes,bytes,bytes,bytes),(address,bytes32,bytes),(address,address,bytes32,bytes32))":{"params":{"_dispute":"The dispute data.","_disputeId":"The ID of the dispute to update the status for.","_request":"The request data.","_response":"The disputed response."}},"pledgeAgainstDispute((uint96,address,address,address,address,address,address,bytes,bytes,bytes,bytes,bytes),(address,address,bytes32,bytes32))":{"details":"Will revert if the disputeId is not going through the bond escalation process.If the bond escalation is not tied at the end of its deadline, a tying buffer is added      to avoid scenarios where one of the parties breaks the tie very last second.      During the tying buffer, the losing party can only tie, and once the escalation is tied      no further funds can be pledged.","params":{"_dispute":"The dispute data.","_request":"The request data."}},"pledgeForDispute((uint96,address,address,address,address,address,address,bytes,bytes,bytes,bytes,bytes),(address,address,bytes32,bytes32))":{"details":"If the bond escalation is not tied at the end of its deadline, a tying buffer is added      to avoid scenarios where one of the parties breaks the tie very last second.      During the tying buffer, the losing party can only tie, and once the escalation is tied      no further funds can be pledged.","params":{"_dispute":"The dispute data.","_request":"The request data."}},"settleBondEscalation((uint96,address,address,address,address,address,address,bytes,bytes,bytes,bytes,bytes),(address,bytes32,bytes),(address,address,bytes32,bytes32))":{"details":"Can only be called if after the deadline + tyingBuffer window is over, the pledges weren\'t tied","params":{"_dispute":"The dispute data.","_request":"The request data.","_response":"The response data."}},"validateParameters(bytes)":{"params":{"_encodedParameters":"The encoded parameters for the request"},"returns":{"_valid":"Boolean indicating if the parameters are valid or not"}}},"stateVariables":{"pledgesAgainstDispute":{"params":{"_pledger":"The address of the pledger to get the pledges for.","_requestId":"The id of the request to get the pledges for."},"return":"pledges The number of pledges made by the pledger against the dispute.","returns":{"pledges":"The number of pledges made by the pledger against the dispute."}},"pledgesForDispute":{"params":{"_pledger":"The address of the pledger to get the pledges for.","_requestId":"The id of the request to get the pledges for."},"return":"pledges The number of pledges made by the pledger for the dispute.","returns":{"pledges":"The number of pledges made by the pledger for the dispute."}}},"version":1},"userdoc":{"errors":{"BondEscalationModule_BondEscalationCantBeSettled()":[{"notice":"Thrown when trying to settle a dispute that went through the bond escalation when it\'s not active."}],"BondEscalationModule_BondEscalationNotOver()":[{"notice":"Thrown when trying to escalate a dispute going through the bond escalation module before its deadline."}],"BondEscalationModule_BondEscalationOver()":[{"notice":"Thrown when trying to pledge after the bond escalation deadline."}],"BondEscalationModule_CanOnlySurpassByOnePledge()":[{"notice":"Thrown when trying to surpass the number of pledges of the other side by more than 1 in the bond escalation mechanism."}],"BondEscalationModule_CannotBreakTieDuringTyingBuffer()":[{"notice":"Thrown when trying to break a tie after the tying buffer has started."}],"BondEscalationModule_DisputeDoesNotExist()":[{"notice":"Thrown when trying to pledge for a dispute that does not exist"}],"BondEscalationModule_DisputeWindowOver()":[{"notice":"Thrown when trying to dispute a response after the dispute period expired."}],"BondEscalationModule_InvalidDispute()":[{"notice":"Thrown when trying to pledge for a dispute that is not going through the bond escalation mechanism."}],"BondEscalationModule_InvalidEscalationParameters()":[{"notice":"Thrown when trying to set up a request with invalid bond size or maximum amount of escalations."}],"BondEscalationModule_MaxNumberOfEscalationsReached()":[{"notice":"Thrown when the number of escalation pledges of a given dispute has reached its maximum."}],"BondEscalationModule_NotEscalatable()":[{"notice":"Thrown when trying to escalate a dispute going through the bond escalation process that is not tied         or that is not active."}],"BondEscalationModule_ShouldBeEscalated()":[{"notice":"Thrown when trying to settle a bond escalation process that is not tied."}],"BondEscalationModule_ZeroValue()":[{"notice":"Thrown when the max number of escalations or the bond size is set to 0."}],"Module_OnlyOracle()":[{"notice":"Thrown when the caller is not the oracle"}],"Validator_InvalidDispute()":[{"notice":"Thrown when the dispute provided does not exist"}],"Validator_InvalidResponse()":[{"notice":"Thrown when the response provided does not exist"}]},"events":{"BondEscalationStatusUpdated(bytes32,bytes32,uint8)":{"notice":"The status of the bond escalation mechanism has been updated."},"DisputeStatusChanged(bytes32,(address,address,bytes32,bytes32),uint8)":{"notice":"Emitted when a dispute status is updated"},"PledgedAgainstDispute(bytes32,address,uint256)":{"notice":"A pledge has been made against a dispute."},"PledgedForDispute(bytes32,address,uint256)":{"notice":"A pledge has been made in favor of a dispute."},"RequestFinalized(bytes32,(address,bytes32,bytes),address)":{"notice":"Emitted when a request is finalized"},"ResponseDisputed(bytes32,bytes32,bytes32,(address,address,bytes32,bytes32),uint256)":{"notice":"Emitted when a response is disputed"}},"kind":"user","methods":{"ORACLE()":{"notice":"The oracle contract"},"decodeRequestData(bytes)":{"notice":"Returns the decoded data for a request"},"disputeResponse((uint96,address,address,address,address,address,address,bytes,bytes,bytes,bytes,bytes),(address,bytes32,bytes),(address,address,bytes32,bytes32))":{"notice":"Disputes a response"},"finalizeRequest((uint96,address,address,address,address,address,address,bytes,bytes,bytes,bytes,bytes),(address,bytes32,bytes),address)":{"notice":"Finalizes the request"},"getEscalation(bytes32)":{"notice":"Returns the escalation data for a request."},"moduleName()":{"notice":"Returns the name of the module."},"onDisputeStatusChange(bytes32,(uint96,address,address,address,address,address,address,bytes,bytes,bytes,bytes,bytes),(address,bytes32,bytes),(address,address,bytes32,bytes32))":{"notice":"Updates the status of a given disputeId and pays the proposer and disputer accordingly. If this         dispute has gone through the bond escalation mechanism, then it will pay the winning pledgers as well."},"pledgeAgainstDispute((uint96,address,address,address,address,address,address,bytes,bytes,bytes,bytes,bytes),(address,address,bytes32,bytes32))":{"notice":"Pledges funds against a given disputeId during its bond escalation process."},"pledgeForDispute((uint96,address,address,address,address,address,address,bytes,bytes,bytes,bytes,bytes),(address,address,bytes32,bytes32))":{"notice":"Bonds funds in favor of a given dispute during the bond escalation process."},"pledgesAgainstDispute(bytes32,address)":{"notice":"Returns the amount of pledges that a particular pledger has made against a given dispute."},"pledgesForDispute(bytes32,address)":{"notice":"Returns the amount of pledges that a particular pledger has made for a given dispute."},"settleBondEscalation((uint96,address,address,address,address,address,address,bytes,bytes,bytes,bytes,bytes),(address,bytes32,bytes),(address,address,bytes32,bytes32))":{"notice":"Settles the bond escalation process of a given requestId."},"validateParameters(bytes)":{"notice":"Validates parameters prior to creating a request"}},"version":1}},"settings":{"compilationTarget":{"solidity/contracts/modules/dispute/BondEscalationModule.sol":"BondEscalationModule"},"evmVersion":"paris","libraries":{},"metadata":{"bytecodeHash":"ipfs"},"optimizer":{"enabled":true,"runs":10000},"remappings":[":@defi-wonderland/=node_modules/@defi-wonderland/",":@openzeppelin/=node_modules/@openzeppelin/",":ds-test/=node_modules/ds-test/src/",":forge-std/=node_modules/forge-std/src/",":solmate/=node_modules/solmate/src/"]},"sources":{"node_modules/@defi-wonderland/prophet-core/solidity/contracts/Module.sol":{"keccak256":"0xf1cc2b38026d6ceac64603b09c495703b28bff3bb16759538328771583c55b8f","license":"MIT","urls":["bzz-raw://c494462ff30a687311169777253165ece60a7ab41a10befe5595c2d912610120","dweb:/ipfs/QmfWr8nPriXt6HrxbYx65xA2ACmJBXWBSUjCLrN783vErZ"]},"node_modules/@defi-wonderland/prophet-core/solidity/contracts/Validator.sol":{"keccak256":"0x5a06b99d5dd53c00c76a8195a72c0afaa801e343eae449d00c502571967343aa","license":"MIT","urls":["bzz-raw://f576bcad599cd37f6f34d9760a469dd4948872e38db74946947904d642a52b72","dweb:/ipfs/QmXAyxczdwmSFHoix1zQqdAtANf1uRfqTQZjBkDWfWmRE9"]},"node_modules/@defi-wonderland/prophet-core/solidity/interfaces/IModule.sol":{"keccak256":"0x68ee41846e0dc31a48b9e4fa1056f914748cec29c64e79272d994fcdf74277c9","license":"MIT","urls":["bzz-raw://3d22e0e329c145e6532f7a52baccb26ab3443d74a7d6573f6348fafb27ca91cd","dweb:/ipfs/QmQDx1aTsM7tCvvUAgPSmJp1xVYudvciNEvq6X1nLXwSnM"]},"node_modules/@defi-wonderland/prophet-core/solidity/interfaces/IOracle.sol":{"keccak256":"0xe209995220c3a9f21b9dc3ca218551a203b7312585de580f5b35f8056c8a1e43","license":"MIT","urls":["bzz-raw://f892e60fef98e11d7f52540e16b6cc1c0ff9329387ed69a3ac0240efce6c868f","dweb:/ipfs/QmNRXwSzcDCbq8WsjkTaoBFki8ZA1afqRGpsCqVswWmsvY"]},"node_modules/@defi-wonderland/prophet-core/solidity/interfaces/IValidator.sol":{"keccak256":"0x19495833d4bfbe88d44b7576f2b02b5a0bb9ffc2d91a86961b4065df64d054b9","license":"MIT","urls":["bzz-raw://ad23d158629b23dc31b9e2a4e75a4abf4b5cad40ee3e9f4f9efd9ae185ceec75","dweb:/ipfs/QmNWbbQaCS6dGcPiw49cJ7A7VaHUxNbEd5vvd4KcAgSxNX"]},"node_modules/@defi-wonderland/prophet-core/solidity/interfaces/modules/dispute/IDisputeModule.sol":{"keccak256":"0x105959eaa1caf78b7dfcc5685cbbfb0f765ba4ec8eea12af180309dd2c1894c7","license":"MIT","urls":["bzz-raw://e29ea2fe3abe20b25846828970a101ed3f2283f3b842e9dacf44e427f86d75dc","dweb:/ipfs/QmRYCzGN8qSW3RvqvANzFuX2SD1W9W69AcCAYnA1RQ4PU1"]},"node_modules/@defi-wonderland/prophet-core/solidity/libraries/ValidatorLib.sol":{"keccak256":"0x9b4ac36694e207c3b53e0369c8b7340864f807d4e07fb8042ef6ea414fcb4ea0","license":"MIT","urls":["bzz-raw://2e9c9845bcf35cfdf1a3450f46c59461cdc9aee95b98e1b34f11187b1b0ca3be","dweb:/ipfs/QmQJqsMzFN6FQeZvGj894mm7ckTqYkpvxpCHAKuY7PA5Dt"]},"node_modules/@openzeppelin/contracts/token/ERC20/IERC20.sol":{"keccak256":"0x287b55befed2961a7eabd7d7b1b2839cbca8a5b80ef8dcbb25ed3d4c2002c305","license":"MIT","urls":["bzz-raw://bd39944e8fc06be6dbe2dd1d8449b5336e23c6a7ba3e8e9ae5ae0f37f35283f5","dweb:/ipfs/QmPV3FGYjVwvKSgAXKUN3r9T9GwniZz83CxBpM7vyj2G53"]},"node_modules/solmate/src/utils/FixedPointMathLib.sol":{"keccak256":"0x1b62af9baf5b8e991ed7531bc87f45550ba9d61e8dbff5caf237ccaf3a3fd843","license":"AGPL-3.0-only","urls":["bzz-raw://b7b38b977c5305b18ceefbeed4c9ceaaaefa419b520de62de6604ea661f8c0a9","dweb:/ipfs/QmecMRzgfMyDVa2pvBqMMDLYBappaj7Aa3qcMoQYEQrhWi"]},"solidity/contracts/modules/dispute/BondEscalationModule.sol":{"keccak256":"0xca5bab50973326f18e773eabf1943a6ba87cb012eaccd8764cb2fe871500bff9","license":"MIT","urls":["bzz-raw://50e1c4811d0e8e95e8955e772c6d081d9bc6447b8517ac946a26ae043077a765","dweb:/ipfs/QmaNYzCmhtkV9voi4G7dxnu7shfmk88iKtdwp8PVdEHZpQ"]},"solidity/interfaces/extensions/IAccountingExtension.sol":{"keccak256":"0xf5a6798f05097db052b75e3863b744acffa3553f360a937769cf48085df03372","license":"MIT","urls":["bzz-raw://941a90aa620ba7f0719adcf816cb3f1cf2614601165f83024f85320f51de0a64","dweb:/ipfs/QmZrHjveVuVBXz8GUBec3tDGNYRrF4YFyfcHCpQTfGVfF4"]},"solidity/interfaces/extensions/IBondEscalationAccounting.sol":{"keccak256":"0xd015b2ae12f7bfaacfeb44a80a110f712e2695c8e4b55e44f198304a49cecc0d","license":"MIT","urls":["bzz-raw://76bd7aba416cb7f6259565477c03f47b1cfd63ff873c9952ddddb10ddd1b1e0e","dweb:/ipfs/QmSwTmwTmgusGrXgcyg5t66y2FR2sqYQwKWcozBLSqmGTo"]},"solidity/interfaces/modules/dispute/IBondEscalationModule.sol":{"keccak256":"0xbb9c791dd188b144632b6cfdc180dd42c4761d6ea2193ed93021a82abd055020","license":"MIT","urls":["bzz-raw://b962d6df377cdb83187d35daf3c7faa8758ec13f6d53a01d8d6c874f9ccb870a","dweb:/ipfs/QmQoadeFhNndmE4JEzxpcr6YgHUKMPUoy1Go22hZWJk36A"]}},"version":1}',
-        metadata: {
-            compiler: { version: "0.8.19+commit.7dd6d404" },
-            language: "Solidity",
-            output: {
-                abi: [
-                    {
-                        inputs: [
-                            { internalType: "contract IOracle", name: "_oracle", type: "address" },
-                        ],
-                        stateMutability: "nonpayable",
-                        type: "constructor",
-                    },
-                    {
-                        inputs: [],
-                        type: "error",
-                        name: "BondEscalationModule_BondEscalationCantBeSettled",
-                    },
-                    {
-                        inputs: [],
-                        type: "error",
-                        name: "BondEscalationModule_BondEscalationNotOver",
-                    },
-                    { inputs: [], type: "error", name: "BondEscalationModule_BondEscalationOver" },
-                    {
-                        inputs: [],
-                        type: "error",
-                        name: "BondEscalationModule_CanOnlySurpassByOnePledge",
-                    },
-                    {
-                        inputs: [],
-                        type: "error",
-                        name: "BondEscalationModule_CannotBreakTieDuringTyingBuffer",
-                    },
-                    { inputs: [], type: "error", name: "BondEscalationModule_DisputeDoesNotExist" },
-                    { inputs: [], type: "error", name: "BondEscalationModule_DisputeWindowOver" },
-                    { inputs: [], type: "error", name: "BondEscalationModule_InvalidDispute" },
-                    {
-                        inputs: [],
-                        type: "error",
-                        name: "BondEscalationModule_InvalidEscalationParameters",
-                    },
-                    {
-                        inputs: [],
-                        type: "error",
-                        name: "BondEscalationModule_MaxNumberOfEscalationsReached",
-                    },
-                    { inputs: [], type: "error", name: "BondEscalationModule_NotEscalatable" },
-                    { inputs: [], type: "error", name: "BondEscalationModule_ShouldBeEscalated" },
-                    { inputs: [], type: "error", name: "BondEscalationModule_ZeroValue" },
-                    { inputs: [], type: "error", name: "Module_OnlyOracle" },
-                    { inputs: [], type: "error", name: "Validator_InvalidDispute" },
-                    { inputs: [], type: "error", name: "Validator_InvalidResponse" },
-                    {
-                        inputs: [
-                            {
-                                internalType: "bytes32",
-                                name: "_requestId",
-                                type: "bytes32",
-                                indexed: true,
-                            },
-                            {
-                                internalType: "bytes32",
-                                name: "_disputeId",
-                                type: "bytes32",
-                                indexed: true,
-                            },
-                            {
-                                internalType: "enum IBondEscalationModule.BondEscalationStatus",
-                                name: "_status",
-                                type: "uint8",
-                                indexed: false,
-                            },
-                        ],
-                        type: "event",
-                        name: "BondEscalationStatusUpdated",
-                        anonymous: false,
-                    },
-                    {
-                        inputs: [
-                            {
-                                internalType: "bytes32",
-                                name: "_disputeId",
-                                type: "bytes32",
-                                indexed: true,
-                            },
-                            {
-                                internalType: "struct IOracle.Dispute",
-                                name: "_dispute",
-                                type: "tuple",
-                                components: [
-                                    { internalType: "address", name: "disputer", type: "address" },
-                                    { internalType: "address", name: "proposer", type: "address" },
-                                    {
-                                        internalType: "bytes32",
-                                        name: "responseId",
-                                        type: "bytes32",
-                                    },
-                                    { internalType: "bytes32", name: "requestId", type: "bytes32" },
-                                ],
-                                indexed: false,
-                            },
-                            {
-                                internalType: "enum IOracle.DisputeStatus",
-                                name: "_status",
-                                type: "uint8",
-                                indexed: false,
-                            },
-                        ],
-                        type: "event",
-                        name: "DisputeStatusChanged",
-                        anonymous: false,
-                    },
-                    {
-                        inputs: [
-                            {
-                                internalType: "bytes32",
-                                name: "_disputeId",
-                                type: "bytes32",
-                                indexed: true,
-                            },
-                            {
-                                internalType: "address",
-                                name: "_pledger",
-                                type: "address",
-                                indexed: true,
-                            },
-                            {
-                                internalType: "uint256",
-                                name: "_amount",
-                                type: "uint256",
-                                indexed: true,
-                            },
-                        ],
-                        type: "event",
-                        name: "PledgedAgainstDispute",
-                        anonymous: false,
-                    },
-                    {
-                        inputs: [
-                            {
-                                internalType: "bytes32",
-                                name: "_disputeId",
-                                type: "bytes32",
-                                indexed: true,
-                            },
-                            {
-                                internalType: "address",
-                                name: "_pledger",
-                                type: "address",
-                                indexed: true,
-                            },
-                            {
-                                internalType: "uint256",
-                                name: "_amount",
-                                type: "uint256",
-                                indexed: true,
-                            },
-                        ],
-                        type: "event",
-                        name: "PledgedForDispute",
-                        anonymous: false,
-                    },
-                    {
-                        inputs: [
-                            {
-                                internalType: "bytes32",
-                                name: "_requestId",
-                                type: "bytes32",
-                                indexed: true,
-                            },
-                            {
-                                internalType: "struct IOracle.Response",
-                                name: "_response",
-                                type: "tuple",
-                                components: [
-                                    { internalType: "address", name: "proposer", type: "address" },
-                                    { internalType: "bytes32", name: "requestId", type: "bytes32" },
-                                    { internalType: "bytes", name: "response", type: "bytes" },
-                                ],
-                                indexed: false,
-                            },
-                            {
-                                internalType: "address",
-                                name: "_finalizer",
-                                type: "address",
-                                indexed: false,
-                            },
-                        ],
-                        type: "event",
-                        name: "RequestFinalized",
-                        anonymous: false,
-                    },
-                    {
-                        inputs: [
-                            {
-                                internalType: "bytes32",
-                                name: "_requestId",
-                                type: "bytes32",
-                                indexed: true,
-                            },
-                            {
-                                internalType: "bytes32",
-                                name: "_responseId",
-                                type: "bytes32",
-                                indexed: true,
-                            },
-                            {
-                                internalType: "bytes32",
-                                name: "_disputeId",
-                                type: "bytes32",
-                                indexed: true,
-                            },
-                            {
-                                internalType: "struct IOracle.Dispute",
-                                name: "_dispute",
-                                type: "tuple",
-                                components: [
-                                    { internalType: "address", name: "disputer", type: "address" },
-                                    { internalType: "address", name: "proposer", type: "address" },
-                                    {
-                                        internalType: "bytes32",
-                                        name: "responseId",
-                                        type: "bytes32",
-                                    },
-                                    { internalType: "bytes32", name: "requestId", type: "bytes32" },
-                                ],
-                                indexed: false,
-                            },
-                            {
-                                internalType: "uint256",
-                                name: "_blockNumber",
-                                type: "uint256",
-                                indexed: false,
-                            },
-                        ],
-                        type: "event",
-                        name: "ResponseDisputed",
-                        anonymous: false,
-                    },
-                    {
-                        inputs: [],
-                        stateMutability: "view",
-                        type: "function",
-                        name: "ORACLE",
-                        outputs: [{ internalType: "contract IOracle", name: "", type: "address" }],
-                    },
-                    {
-                        inputs: [{ internalType: "bytes", name: "_data", type: "bytes" }],
-                        stateMutability: "pure",
-                        type: "function",
-                        name: "decodeRequestData",
-                        outputs: [
-                            {
-                                internalType: "struct IBondEscalationModule.RequestParameters",
-                                name: "_params",
-                                type: "tuple",
-                                components: [
-                                    {
-                                        internalType: "contract IBondEscalationAccounting",
-                                        name: "accountingExtension",
-                                        type: "address",
-                                    },
-                                    {
-                                        internalType: "contract IERC20",
-                                        name: "bondToken",
-                                        type: "address",
-                                    },
-                                    { internalType: "uint256", name: "bondSize", type: "uint256" },
-                                    {
-                                        internalType: "uint256",
-                                        name: "maxNumberOfEscalations",
-                                        type: "uint256",
-                                    },
-                                    {
-                                        internalType: "uint256",
-                                        name: "bondEscalationDeadline",
-                                        type: "uint256",
-                                    },
-                                    {
-                                        internalType: "uint256",
-                                        name: "tyingBuffer",
-                                        type: "uint256",
-                                    },
-                                    {
-                                        internalType: "uint256",
-                                        name: "disputeWindow",
-                                        type: "uint256",
-                                    },
-                                ],
-                            },
-                        ],
-                    },
-                    {
-                        inputs: [
-                            {
-                                internalType: "struct IOracle.Request",
-                                name: "_request",
-                                type: "tuple",
-                                components: [
-                                    { internalType: "uint96", name: "nonce", type: "uint96" },
-                                    { internalType: "address", name: "requester", type: "address" },
-                                    {
-                                        internalType: "address",
-                                        name: "requestModule",
-                                        type: "address",
-                                    },
-                                    {
-                                        internalType: "address",
-                                        name: "responseModule",
-                                        type: "address",
-                                    },
-                                    {
-                                        internalType: "address",
-                                        name: "disputeModule",
-                                        type: "address",
-                                    },
-                                    {
-                                        internalType: "address",
-                                        name: "resolutionModule",
-                                        type: "address",
-                                    },
-                                    {
-                                        internalType: "address",
-                                        name: "finalityModule",
-                                        type: "address",
-                                    },
-                                    {
-                                        internalType: "bytes",
-                                        name: "requestModuleData",
-                                        type: "bytes",
-                                    },
-                                    {
-                                        internalType: "bytes",
-                                        name: "responseModuleData",
-                                        type: "bytes",
-                                    },
-                                    {
-                                        internalType: "bytes",
-                                        name: "disputeModuleData",
-                                        type: "bytes",
-                                    },
-                                    {
-                                        internalType: "bytes",
-                                        name: "resolutionModuleData",
-                                        type: "bytes",
-                                    },
-                                    {
-                                        internalType: "bytes",
-                                        name: "finalityModuleData",
-                                        type: "bytes",
-                                    },
-                                ],
-                            },
-                            {
-                                internalType: "struct IOracle.Response",
-                                name: "_response",
-                                type: "tuple",
-                                components: [
-                                    { internalType: "address", name: "proposer", type: "address" },
-                                    { internalType: "bytes32", name: "requestId", type: "bytes32" },
-                                    { internalType: "bytes", name: "response", type: "bytes" },
-                                ],
-                            },
-                            {
-                                internalType: "struct IOracle.Dispute",
-                                name: "_dispute",
-                                type: "tuple",
-                                components: [
-                                    { internalType: "address", name: "disputer", type: "address" },
-                                    { internalType: "address", name: "proposer", type: "address" },
-                                    {
-                                        internalType: "bytes32",
-                                        name: "responseId",
-                                        type: "bytes32",
-                                    },
-                                    { internalType: "bytes32", name: "requestId", type: "bytes32" },
-                                ],
-                            },
-                        ],
-                        stateMutability: "nonpayable",
-                        type: "function",
-                        name: "disputeResponse",
-                    },
-                    {
-                        inputs: [
-                            {
-                                internalType: "struct IOracle.Request",
-                                name: "_request",
-                                type: "tuple",
-                                components: [
-                                    { internalType: "uint96", name: "nonce", type: "uint96" },
-                                    { internalType: "address", name: "requester", type: "address" },
-                                    {
-                                        internalType: "address",
-                                        name: "requestModule",
-                                        type: "address",
-                                    },
-                                    {
-                                        internalType: "address",
-                                        name: "responseModule",
-                                        type: "address",
-                                    },
-                                    {
-                                        internalType: "address",
-                                        name: "disputeModule",
-                                        type: "address",
-                                    },
-                                    {
-                                        internalType: "address",
-                                        name: "resolutionModule",
-                                        type: "address",
-                                    },
-                                    {
-                                        internalType: "address",
-                                        name: "finalityModule",
-                                        type: "address",
-                                    },
-                                    {
-                                        internalType: "bytes",
-                                        name: "requestModuleData",
-                                        type: "bytes",
-                                    },
-                                    {
-                                        internalType: "bytes",
-                                        name: "responseModuleData",
-                                        type: "bytes",
-                                    },
-                                    {
-                                        internalType: "bytes",
-                                        name: "disputeModuleData",
-                                        type: "bytes",
-                                    },
-                                    {
-                                        internalType: "bytes",
-                                        name: "resolutionModuleData",
-                                        type: "bytes",
-                                    },
-                                    {
-                                        internalType: "bytes",
-                                        name: "finalityModuleData",
-                                        type: "bytes",
-                                    },
-                                ],
-                            },
-                            {
-                                internalType: "struct IOracle.Response",
-                                name: "_response",
-                                type: "tuple",
-                                components: [
-                                    { internalType: "address", name: "proposer", type: "address" },
-                                    { internalType: "bytes32", name: "requestId", type: "bytes32" },
-                                    { internalType: "bytes", name: "response", type: "bytes" },
-                                ],
-                            },
-                            { internalType: "address", name: "_finalizer", type: "address" },
-                        ],
-                        stateMutability: "nonpayable",
-                        type: "function",
-                        name: "finalizeRequest",
-                    },
-                    {
-                        inputs: [{ internalType: "bytes32", name: "_requestId", type: "bytes32" }],
-                        stateMutability: "view",
-                        type: "function",
-                        name: "getEscalation",
-                        outputs: [
-                            {
-                                internalType: "struct IBondEscalationModule.BondEscalation",
-                                name: "_escalation",
-                                type: "tuple",
-                                components: [
-                                    { internalType: "bytes32", name: "disputeId", type: "bytes32" },
-                                    {
-                                        internalType:
-                                            "enum IBondEscalationModule.BondEscalationStatus",
-                                        name: "status",
-                                        type: "uint8",
-                                    },
-                                    {
-                                        internalType: "uint256",
-                                        name: "amountOfPledgesForDispute",
-                                        type: "uint256",
-                                    },
-                                    {
-                                        internalType: "uint256",
-                                        name: "amountOfPledgesAgainstDispute",
-                                        type: "uint256",
-                                    },
-                                ],
-                            },
-                        ],
-                    },
-                    {
-                        inputs: [],
-                        stateMutability: "pure",
-                        type: "function",
-                        name: "moduleName",
-                        outputs: [{ internalType: "string", name: "_moduleName", type: "string" }],
-                    },
-                    {
-                        inputs: [
-                            { internalType: "bytes32", name: "_disputeId", type: "bytes32" },
-                            {
-                                internalType: "struct IOracle.Request",
-                                name: "_request",
-                                type: "tuple",
-                                components: [
-                                    { internalType: "uint96", name: "nonce", type: "uint96" },
-                                    { internalType: "address", name: "requester", type: "address" },
-                                    {
-                                        internalType: "address",
-                                        name: "requestModule",
-                                        type: "address",
-                                    },
-                                    {
-                                        internalType: "address",
-                                        name: "responseModule",
-                                        type: "address",
-                                    },
-                                    {
-                                        internalType: "address",
-                                        name: "disputeModule",
-                                        type: "address",
-                                    },
-                                    {
-                                        internalType: "address",
-                                        name: "resolutionModule",
-                                        type: "address",
-                                    },
-                                    {
-                                        internalType: "address",
-                                        name: "finalityModule",
-                                        type: "address",
-                                    },
-                                    {
-                                        internalType: "bytes",
-                                        name: "requestModuleData",
-                                        type: "bytes",
-                                    },
-                                    {
-                                        internalType: "bytes",
-                                        name: "responseModuleData",
-                                        type: "bytes",
-                                    },
-                                    {
-                                        internalType: "bytes",
-                                        name: "disputeModuleData",
-                                        type: "bytes",
-                                    },
-                                    {
-                                        internalType: "bytes",
-                                        name: "resolutionModuleData",
-                                        type: "bytes",
-                                    },
-                                    {
-                                        internalType: "bytes",
-                                        name: "finalityModuleData",
-                                        type: "bytes",
-                                    },
-                                ],
-                            },
-                            {
-                                internalType: "struct IOracle.Response",
-                                name: "",
-                                type: "tuple",
-                                components: [
-                                    { internalType: "address", name: "proposer", type: "address" },
-                                    { internalType: "bytes32", name: "requestId", type: "bytes32" },
-                                    { internalType: "bytes", name: "response", type: "bytes" },
-                                ],
-                            },
-                            {
-                                internalType: "struct IOracle.Dispute",
-                                name: "_dispute",
-                                type: "tuple",
-                                components: [
-                                    { internalType: "address", name: "disputer", type: "address" },
-                                    { internalType: "address", name: "proposer", type: "address" },
-                                    {
-                                        internalType: "bytes32",
-                                        name: "responseId",
-                                        type: "bytes32",
-                                    },
-                                    { internalType: "bytes32", name: "requestId", type: "bytes32" },
-                                ],
-                            },
-                        ],
-                        stateMutability: "nonpayable",
-                        type: "function",
-                        name: "onDisputeStatusChange",
-                    },
-                    {
-                        inputs: [
-                            {
-                                internalType: "struct IOracle.Request",
-                                name: "_request",
-                                type: "tuple",
-                                components: [
-                                    { internalType: "uint96", name: "nonce", type: "uint96" },
-                                    { internalType: "address", name: "requester", type: "address" },
-                                    {
-                                        internalType: "address",
-                                        name: "requestModule",
-                                        type: "address",
-                                    },
-                                    {
-                                        internalType: "address",
-                                        name: "responseModule",
-                                        type: "address",
-                                    },
-                                    {
-                                        internalType: "address",
-                                        name: "disputeModule",
-                                        type: "address",
-                                    },
-                                    {
-                                        internalType: "address",
-                                        name: "resolutionModule",
-                                        type: "address",
-                                    },
-                                    {
-                                        internalType: "address",
-                                        name: "finalityModule",
-                                        type: "address",
-                                    },
-                                    {
-                                        internalType: "bytes",
-                                        name: "requestModuleData",
-                                        type: "bytes",
-                                    },
-                                    {
-                                        internalType: "bytes",
-                                        name: "responseModuleData",
-                                        type: "bytes",
-                                    },
-                                    {
-                                        internalType: "bytes",
-                                        name: "disputeModuleData",
-                                        type: "bytes",
-                                    },
-                                    {
-                                        internalType: "bytes",
-                                        name: "resolutionModuleData",
-                                        type: "bytes",
-                                    },
-                                    {
-                                        internalType: "bytes",
-                                        name: "finalityModuleData",
-                                        type: "bytes",
-                                    },
-                                ],
-                            },
-                            {
-                                internalType: "struct IOracle.Dispute",
-                                name: "_dispute",
-                                type: "tuple",
-                                components: [
-                                    { internalType: "address", name: "disputer", type: "address" },
-                                    { internalType: "address", name: "proposer", type: "address" },
-                                    {
-                                        internalType: "bytes32",
-                                        name: "responseId",
-                                        type: "bytes32",
-                                    },
-                                    { internalType: "bytes32", name: "requestId", type: "bytes32" },
-                                ],
-                            },
-                        ],
-                        stateMutability: "nonpayable",
-                        type: "function",
-                        name: "pledgeAgainstDispute",
-                    },
-                    {
-                        inputs: [
-                            {
-                                internalType: "struct IOracle.Request",
-                                name: "_request",
-                                type: "tuple",
-                                components: [
-                                    { internalType: "uint96", name: "nonce", type: "uint96" },
-                                    { internalType: "address", name: "requester", type: "address" },
-                                    {
-                                        internalType: "address",
-                                        name: "requestModule",
-                                        type: "address",
-                                    },
-                                    {
-                                        internalType: "address",
-                                        name: "responseModule",
-                                        type: "address",
-                                    },
-                                    {
-                                        internalType: "address",
-                                        name: "disputeModule",
-                                        type: "address",
-                                    },
-                                    {
-                                        internalType: "address",
-                                        name: "resolutionModule",
-                                        type: "address",
-                                    },
-                                    {
-                                        internalType: "address",
-                                        name: "finalityModule",
-                                        type: "address",
-                                    },
-                                    {
-                                        internalType: "bytes",
-                                        name: "requestModuleData",
-                                        type: "bytes",
-                                    },
-                                    {
-                                        internalType: "bytes",
-                                        name: "responseModuleData",
-                                        type: "bytes",
-                                    },
-                                    {
-                                        internalType: "bytes",
-                                        name: "disputeModuleData",
-                                        type: "bytes",
-                                    },
-                                    {
-                                        internalType: "bytes",
-                                        name: "resolutionModuleData",
-                                        type: "bytes",
-                                    },
-                                    {
-                                        internalType: "bytes",
-                                        name: "finalityModuleData",
-                                        type: "bytes",
-                                    },
-                                ],
-                            },
-                            {
-                                internalType: "struct IOracle.Dispute",
-                                name: "_dispute",
-                                type: "tuple",
-                                components: [
-                                    { internalType: "address", name: "disputer", type: "address" },
-                                    { internalType: "address", name: "proposer", type: "address" },
-                                    {
-                                        internalType: "bytes32",
-                                        name: "responseId",
-                                        type: "bytes32",
-                                    },
-                                    { internalType: "bytes32", name: "requestId", type: "bytes32" },
-                                ],
-                            },
-                        ],
-                        stateMutability: "nonpayable",
-                        type: "function",
-                        name: "pledgeForDispute",
-                    },
-                    {
-                        inputs: [
-                            { internalType: "bytes32", name: "_requestId", type: "bytes32" },
-                            { internalType: "address", name: "_pledger", type: "address" },
-                        ],
-                        stateMutability: "view",
-                        type: "function",
-                        name: "pledgesAgainstDispute",
-                        outputs: [{ internalType: "uint256", name: "pledges", type: "uint256" }],
-                    },
-                    {
-                        inputs: [
-                            { internalType: "bytes32", name: "_requestId", type: "bytes32" },
-                            { internalType: "address", name: "_pledger", type: "address" },
-                        ],
-                        stateMutability: "view",
-                        type: "function",
-                        name: "pledgesForDispute",
-                        outputs: [{ internalType: "uint256", name: "pledges", type: "uint256" }],
-                    },
-                    {
-                        inputs: [
-                            {
-                                internalType: "struct IOracle.Request",
-                                name: "_request",
-                                type: "tuple",
-                                components: [
-                                    { internalType: "uint96", name: "nonce", type: "uint96" },
-                                    { internalType: "address", name: "requester", type: "address" },
-                                    {
-                                        internalType: "address",
-                                        name: "requestModule",
-                                        type: "address",
-                                    },
-                                    {
-                                        internalType: "address",
-                                        name: "responseModule",
-                                        type: "address",
-                                    },
-                                    {
-                                        internalType: "address",
-                                        name: "disputeModule",
-                                        type: "address",
-                                    },
-                                    {
-                                        internalType: "address",
-                                        name: "resolutionModule",
-                                        type: "address",
-                                    },
-                                    {
-                                        internalType: "address",
-                                        name: "finalityModule",
-                                        type: "address",
-                                    },
-                                    {
-                                        internalType: "bytes",
-                                        name: "requestModuleData",
-                                        type: "bytes",
-                                    },
-                                    {
-                                        internalType: "bytes",
-                                        name: "responseModuleData",
-                                        type: "bytes",
-                                    },
-                                    {
-                                        internalType: "bytes",
-                                        name: "disputeModuleData",
-                                        type: "bytes",
-                                    },
-                                    {
-                                        internalType: "bytes",
-                                        name: "resolutionModuleData",
-                                        type: "bytes",
-                                    },
-                                    {
-                                        internalType: "bytes",
-                                        name: "finalityModuleData",
-                                        type: "bytes",
-                                    },
-                                ],
-                            },
-                            {
-                                internalType: "struct IOracle.Response",
-                                name: "_response",
-                                type: "tuple",
-                                components: [
-                                    { internalType: "address", name: "proposer", type: "address" },
-                                    { internalType: "bytes32", name: "requestId", type: "bytes32" },
-                                    { internalType: "bytes", name: "response", type: "bytes" },
-                                ],
-                            },
-                            {
-                                internalType: "struct IOracle.Dispute",
-                                name: "_dispute",
-                                type: "tuple",
-                                components: [
-                                    { internalType: "address", name: "disputer", type: "address" },
-                                    { internalType: "address", name: "proposer", type: "address" },
-                                    {
-                                        internalType: "bytes32",
-                                        name: "responseId",
-                                        type: "bytes32",
-                                    },
-                                    { internalType: "bytes32", name: "requestId", type: "bytes32" },
-                                ],
-                            },
-                        ],
-                        stateMutability: "nonpayable",
-                        type: "function",
-                        name: "settleBondEscalation",
-                    },
-                    {
-                        inputs: [
-                            { internalType: "bytes", name: "_encodedParameters", type: "bytes" },
-                        ],
-                        stateMutability: "pure",
-                        type: "function",
-                        name: "validateParameters",
-                        outputs: [{ internalType: "bool", name: "_valid", type: "bool" }],
-                    },
-                ],
-                devdoc: {
-                    kind: "dev",
-                    methods: {
-                        "decodeRequestData(bytes)": {
-                            params: { _data: "The encoded request parameters" },
-                            returns: {
-                                _params: "The struct containing the parameters for the request",
-                            },
-                        },
-                        "disputeResponse((uint96,address,address,address,address,address,address,bytes,bytes,bytes,bytes,bytes),(address,bytes32,bytes),(address,address,bytes32,bytes32))":
-                            {
-                                details:
-                                    "If this is the first dispute of the request and the bond escalation window is not over,      it will start the bond escalation process. This function must be called through the Oracle.",
-                                params: {
-                                    _dispute: "The dispute created by the oracle.",
-                                    _request: "The request data.",
-                                    _response: "The response being disputed.",
-                                },
-                            },
-                        "finalizeRequest((uint96,address,address,address,address,address,address,bytes,bytes,bytes,bytes,bytes),(address,bytes32,bytes),address)":
-                            {
-                                params: {
-                                    _finalizer: "The address that initiated the finalization",
-                                    _request: "The request being finalized",
-                                    _response: "The final response",
-                                },
-                            },
-                        "getEscalation(bytes32)": {
-                            params: {
-                                _requestId: "The id of the request to get its escalation data.",
-                            },
-                            returns: { _escalation: "The struct containing the escalation data." },
-                        },
-                        "moduleName()": { returns: { _moduleName: "The name of the module." } },
-                        "onDisputeStatusChange(bytes32,(uint96,address,address,address,address,address,address,bytes,bytes,bytes,bytes,bytes),(address,bytes32,bytes),(address,address,bytes32,bytes32))":
-                            {
-                                params: {
-                                    _dispute: "The dispute data.",
-                                    _disputeId: "The ID of the dispute to update the status for.",
-                                    _request: "The request data.",
-                                    _response: "The disputed response.",
-                                },
-                            },
-                        "pledgeAgainstDispute((uint96,address,address,address,address,address,address,bytes,bytes,bytes,bytes,bytes),(address,address,bytes32,bytes32))":
-                            {
-                                details:
-                                    "Will revert if the disputeId is not going through the bond escalation process.If the bond escalation is not tied at the end of its deadline, a tying buffer is added      to avoid scenarios where one of the parties breaks the tie very last second.      During the tying buffer, the losing party can only tie, and once the escalation is tied      no further funds can be pledged.",
-                                params: {
-                                    _dispute: "The dispute data.",
-                                    _request: "The request data.",
-                                },
-                            },
-                        "pledgeForDispute((uint96,address,address,address,address,address,address,bytes,bytes,bytes,bytes,bytes),(address,address,bytes32,bytes32))":
-                            {
-                                details:
-                                    "If the bond escalation is not tied at the end of its deadline, a tying buffer is added      to avoid scenarios where one of the parties breaks the tie very last second.      During the tying buffer, the losing party can only tie, and once the escalation is tied      no further funds can be pledged.",
-                                params: {
-                                    _dispute: "The dispute data.",
-                                    _request: "The request data.",
-                                },
-                            },
-                        "settleBondEscalation((uint96,address,address,address,address,address,address,bytes,bytes,bytes,bytes,bytes),(address,bytes32,bytes),(address,address,bytes32,bytes32))":
-                            {
-                                details:
-                                    "Can only be called if after the deadline + tyingBuffer window is over, the pledges weren't tied",
-                                params: {
-                                    _dispute: "The dispute data.",
-                                    _request: "The request data.",
-                                    _response: "The response data.",
-                                },
-                            },
-                        "validateParameters(bytes)": {
-                            params: {
-                                _encodedParameters: "The encoded parameters for the request",
-                            },
-                            returns: {
-                                _valid: "Boolean indicating if the parameters are valid or not",
-                            },
-                        },
-                    },
-                    version: 1,
-                },
-                userdoc: {
-                    kind: "user",
-                    methods: {
-                        "ORACLE()": { notice: "The oracle contract" },
-                        "decodeRequestData(bytes)": {
-                            notice: "Returns the decoded data for a request",
-                        },
-                        "disputeResponse((uint96,address,address,address,address,address,address,bytes,bytes,bytes,bytes,bytes),(address,bytes32,bytes),(address,address,bytes32,bytes32))":
-                            { notice: "Disputes a response" },
-                        "finalizeRequest((uint96,address,address,address,address,address,address,bytes,bytes,bytes,bytes,bytes),(address,bytes32,bytes),address)":
-                            { notice: "Finalizes the request" },
-                        "getEscalation(bytes32)": {
-                            notice: "Returns the escalation data for a request.",
-                        },
-                        "moduleName()": { notice: "Returns the name of the module." },
-                        "onDisputeStatusChange(bytes32,(uint96,address,address,address,address,address,address,bytes,bytes,bytes,bytes,bytes),(address,bytes32,bytes),(address,address,bytes32,bytes32))":
-                            {
-                                notice: "Updates the status of a given disputeId and pays the proposer and disputer accordingly. If this         dispute has gone through the bond escalation mechanism, then it will pay the winning pledgers as well.",
-                            },
-                        "pledgeAgainstDispute((uint96,address,address,address,address,address,address,bytes,bytes,bytes,bytes,bytes),(address,address,bytes32,bytes32))":
-                            {
-                                notice: "Pledges funds against a given disputeId during its bond escalation process.",
-                            },
-                        "pledgeForDispute((uint96,address,address,address,address,address,address,bytes,bytes,bytes,bytes,bytes),(address,address,bytes32,bytes32))":
-                            {
-                                notice: "Bonds funds in favor of a given dispute during the bond escalation process.",
-                            },
-                        "pledgesAgainstDispute(bytes32,address)": {
-                            notice: "Returns the amount of pledges that a particular pledger has made against a given dispute.",
-                        },
-                        "pledgesForDispute(bytes32,address)": {
-                            notice: "Returns the amount of pledges that a particular pledger has made for a given dispute.",
-                        },
-                        "settleBondEscalation((uint96,address,address,address,address,address,address,bytes,bytes,bytes,bytes,bytes),(address,bytes32,bytes),(address,address,bytes32,bytes32))":
-                            { notice: "Settles the bond escalation process of a given requestId." },
-                        "validateParameters(bytes)": {
-                            notice: "Validates parameters prior to creating a request",
-                        },
-                    },
-                    version: 1,
-                },
-            },
-            settings: {
-                remappings: [
-                    "@defi-wonderland/=node_modules/@defi-wonderland/",
-                    "@openzeppelin/=node_modules/@openzeppelin/",
-                    "ds-test/=node_modules/ds-test/src/",
-                    "forge-std/=node_modules/forge-std/src/",
-                    "solmate/=node_modules/solmate/src/",
-                ],
-                optimizer: { enabled: true, runs: 10000 },
-                metadata: { bytecodeHash: "ipfs" },
-                compilationTarget: {
-                    "solidity/contracts/modules/dispute/BondEscalationModule.sol":
-                        "BondEscalationModule",
-                },
-                evmVersion: "paris",
-                libraries: {},
-            },
-            sources: {
-                "node_modules/@defi-wonderland/prophet-core/solidity/contracts/Module.sol": {
-                    keccak256: "0xf1cc2b38026d6ceac64603b09c495703b28bff3bb16759538328771583c55b8f",
-                    urls: [
-                        "bzz-raw://c494462ff30a687311169777253165ece60a7ab41a10befe5595c2d912610120",
-                        "dweb:/ipfs/QmfWr8nPriXt6HrxbYx65xA2ACmJBXWBSUjCLrN783vErZ",
-                    ],
-                    license: "MIT",
-                },
-                "node_modules/@defi-wonderland/prophet-core/solidity/contracts/Validator.sol": {
-                    keccak256: "0x5a06b99d5dd53c00c76a8195a72c0afaa801e343eae449d00c502571967343aa",
-                    urls: [
-                        "bzz-raw://f576bcad599cd37f6f34d9760a469dd4948872e38db74946947904d642a52b72",
-                        "dweb:/ipfs/QmXAyxczdwmSFHoix1zQqdAtANf1uRfqTQZjBkDWfWmRE9",
-                    ],
-                    license: "MIT",
-                },
-                "node_modules/@defi-wonderland/prophet-core/solidity/interfaces/IModule.sol": {
-                    keccak256: "0x68ee41846e0dc31a48b9e4fa1056f914748cec29c64e79272d994fcdf74277c9",
-                    urls: [
-                        "bzz-raw://3d22e0e329c145e6532f7a52baccb26ab3443d74a7d6573f6348fafb27ca91cd",
-                        "dweb:/ipfs/QmQDx1aTsM7tCvvUAgPSmJp1xVYudvciNEvq6X1nLXwSnM",
-                    ],
-                    license: "MIT",
-                },
-                "node_modules/@defi-wonderland/prophet-core/solidity/interfaces/IOracle.sol": {
-                    keccak256: "0xe209995220c3a9f21b9dc3ca218551a203b7312585de580f5b35f8056c8a1e43",
-                    urls: [
-                        "bzz-raw://f892e60fef98e11d7f52540e16b6cc1c0ff9329387ed69a3ac0240efce6c868f",
-                        "dweb:/ipfs/QmNRXwSzcDCbq8WsjkTaoBFki8ZA1afqRGpsCqVswWmsvY",
-                    ],
-                    license: "MIT",
-                },
-                "node_modules/@defi-wonderland/prophet-core/solidity/interfaces/IValidator.sol": {
-                    keccak256: "0x19495833d4bfbe88d44b7576f2b02b5a0bb9ffc2d91a86961b4065df64d054b9",
-                    urls: [
-                        "bzz-raw://ad23d158629b23dc31b9e2a4e75a4abf4b5cad40ee3e9f4f9efd9ae185ceec75",
-                        "dweb:/ipfs/QmNWbbQaCS6dGcPiw49cJ7A7VaHUxNbEd5vvd4KcAgSxNX",
-                    ],
-                    license: "MIT",
-                },
-                "node_modules/@defi-wonderland/prophet-core/solidity/interfaces/modules/dispute/IDisputeModule.sol":
-                    {
-                        keccak256:
-                            "0x105959eaa1caf78b7dfcc5685cbbfb0f765ba4ec8eea12af180309dd2c1894c7",
-                        urls: [
-                            "bzz-raw://e29ea2fe3abe20b25846828970a101ed3f2283f3b842e9dacf44e427f86d75dc",
-                            "dweb:/ipfs/QmRYCzGN8qSW3RvqvANzFuX2SD1W9W69AcCAYnA1RQ4PU1",
-                        ],
-                        license: "MIT",
-                    },
-                "node_modules/@defi-wonderland/prophet-core/solidity/libraries/ValidatorLib.sol": {
-                    keccak256: "0x9b4ac36694e207c3b53e0369c8b7340864f807d4e07fb8042ef6ea414fcb4ea0",
-                    urls: [
-                        "bzz-raw://2e9c9845bcf35cfdf1a3450f46c59461cdc9aee95b98e1b34f11187b1b0ca3be",
-                        "dweb:/ipfs/QmQJqsMzFN6FQeZvGj894mm7ckTqYkpvxpCHAKuY7PA5Dt",
-                    ],
-                    license: "MIT",
-                },
-                "node_modules/@openzeppelin/contracts/token/ERC20/IERC20.sol": {
-                    keccak256: "0x287b55befed2961a7eabd7d7b1b2839cbca8a5b80ef8dcbb25ed3d4c2002c305",
-                    urls: [
-                        "bzz-raw://bd39944e8fc06be6dbe2dd1d8449b5336e23c6a7ba3e8e9ae5ae0f37f35283f5",
-                        "dweb:/ipfs/QmPV3FGYjVwvKSgAXKUN3r9T9GwniZz83CxBpM7vyj2G53",
-                    ],
-                    license: "MIT",
-                },
-                "node_modules/solmate/src/utils/FixedPointMathLib.sol": {
-                    keccak256: "0x1b62af9baf5b8e991ed7531bc87f45550ba9d61e8dbff5caf237ccaf3a3fd843",
-                    urls: [
-                        "bzz-raw://b7b38b977c5305b18ceefbeed4c9ceaaaefa419b520de62de6604ea661f8c0a9",
-                        "dweb:/ipfs/QmecMRzgfMyDVa2pvBqMMDLYBappaj7Aa3qcMoQYEQrhWi",
-                    ],
-                    license: "AGPL-3.0-only",
-                },
-                "solidity/contracts/modules/dispute/BondEscalationModule.sol": {
-                    keccak256: "0xca5bab50973326f18e773eabf1943a6ba87cb012eaccd8764cb2fe871500bff9",
-                    urls: [
-                        "bzz-raw://50e1c4811d0e8e95e8955e772c6d081d9bc6447b8517ac946a26ae043077a765",
-                        "dweb:/ipfs/QmaNYzCmhtkV9voi4G7dxnu7shfmk88iKtdwp8PVdEHZpQ",
-                    ],
-                    license: "MIT",
-                },
-                "solidity/interfaces/extensions/IAccountingExtension.sol": {
-                    keccak256: "0xf5a6798f05097db052b75e3863b744acffa3553f360a937769cf48085df03372",
-                    urls: [
-                        "bzz-raw://941a90aa620ba7f0719adcf816cb3f1cf2614601165f83024f85320f51de0a64",
-                        "dweb:/ipfs/QmZrHjveVuVBXz8GUBec3tDGNYRrF4YFyfcHCpQTfGVfF4",
-                    ],
-                    license: "MIT",
-                },
-                "solidity/interfaces/extensions/IBondEscalationAccounting.sol": {
-                    keccak256: "0xd015b2ae12f7bfaacfeb44a80a110f712e2695c8e4b55e44f198304a49cecc0d",
-                    urls: [
-                        "bzz-raw://76bd7aba416cb7f6259565477c03f47b1cfd63ff873c9952ddddb10ddd1b1e0e",
-                        "dweb:/ipfs/QmSwTmwTmgusGrXgcyg5t66y2FR2sqYQwKWcozBLSqmGTo",
-                    ],
-                    license: "MIT",
-                },
-                "solidity/interfaces/modules/dispute/IBondEscalationModule.sol": {
-                    keccak256: "0xbb9c791dd188b144632b6cfdc180dd42c4761d6ea2193ed93021a82abd055020",
-                    urls: [
-                        "bzz-raw://b962d6df377cdb83187d35daf3c7faa8758ec13f6d53a01d8d6c874f9ccb870a",
-                        "dweb:/ipfs/QmQoadeFhNndmE4JEzxpcr6YgHUKMPUoy1Go22hZWJk36A",
-                    ],
-                    license: "MIT",
-                },
-            },
-            version: 1,
-        },
-        id: 51,
+        stateMutability: "view",
     },
+    {
+        type: "function",
+        name: "moduleName",
+        inputs: [],
+        outputs: [{ name: "_moduleName", type: "string", internalType: "string" }],
+        stateMutability: "pure",
+    },
+    {
+        type: "function",
+        name: "onDisputeStatusChange",
+        inputs: [
+            { name: "_disputeId", type: "bytes32", internalType: "bytes32" },
+            {
+                name: "_request",
+                type: "tuple",
+                internalType: "struct IOracle.Request",
+                components: [
+                    { name: "nonce", type: "uint96", internalType: "uint96" },
+                    { name: "requester", type: "address", internalType: "address" },
+                    { name: "requestModule", type: "address", internalType: "address" },
+                    { name: "responseModule", type: "address", internalType: "address" },
+                    { name: "disputeModule", type: "address", internalType: "address" },
+                    { name: "resolutionModule", type: "address", internalType: "address" },
+                    { name: "finalityModule", type: "address", internalType: "address" },
+                    { name: "requestModuleData", type: "bytes", internalType: "bytes" },
+                    { name: "responseModuleData", type: "bytes", internalType: "bytes" },
+                    { name: "disputeModuleData", type: "bytes", internalType: "bytes" },
+                    { name: "resolutionModuleData", type: "bytes", internalType: "bytes" },
+                    { name: "finalityModuleData", type: "bytes", internalType: "bytes" },
+                ],
+            },
+            {
+                name: "",
+                type: "tuple",
+                internalType: "struct IOracle.Response",
+                components: [
+                    { name: "proposer", type: "address", internalType: "address" },
+                    { name: "requestId", type: "bytes32", internalType: "bytes32" },
+                    { name: "response", type: "bytes", internalType: "bytes" },
+                ],
+            },
+            {
+                name: "_dispute",
+                type: "tuple",
+                internalType: "struct IOracle.Dispute",
+                components: [
+                    { name: "disputer", type: "address", internalType: "address" },
+                    { name: "proposer", type: "address", internalType: "address" },
+                    { name: "responseId", type: "bytes32", internalType: "bytes32" },
+                    { name: "requestId", type: "bytes32", internalType: "bytes32" },
+                ],
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "pledgeAgainstDispute",
+        inputs: [
+            {
+                name: "_request",
+                type: "tuple",
+                internalType: "struct IOracle.Request",
+                components: [
+                    { name: "nonce", type: "uint96", internalType: "uint96" },
+                    { name: "requester", type: "address", internalType: "address" },
+                    { name: "requestModule", type: "address", internalType: "address" },
+                    { name: "responseModule", type: "address", internalType: "address" },
+                    { name: "disputeModule", type: "address", internalType: "address" },
+                    { name: "resolutionModule", type: "address", internalType: "address" },
+                    { name: "finalityModule", type: "address", internalType: "address" },
+                    { name: "requestModuleData", type: "bytes", internalType: "bytes" },
+                    { name: "responseModuleData", type: "bytes", internalType: "bytes" },
+                    { name: "disputeModuleData", type: "bytes", internalType: "bytes" },
+                    { name: "resolutionModuleData", type: "bytes", internalType: "bytes" },
+                    { name: "finalityModuleData", type: "bytes", internalType: "bytes" },
+                ],
+            },
+            {
+                name: "_dispute",
+                type: "tuple",
+                internalType: "struct IOracle.Dispute",
+                components: [
+                    { name: "disputer", type: "address", internalType: "address" },
+                    { name: "proposer", type: "address", internalType: "address" },
+                    { name: "responseId", type: "bytes32", internalType: "bytes32" },
+                    { name: "requestId", type: "bytes32", internalType: "bytes32" },
+                ],
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "pledgeForDispute",
+        inputs: [
+            {
+                name: "_request",
+                type: "tuple",
+                internalType: "struct IOracle.Request",
+                components: [
+                    { name: "nonce", type: "uint96", internalType: "uint96" },
+                    { name: "requester", type: "address", internalType: "address" },
+                    { name: "requestModule", type: "address", internalType: "address" },
+                    { name: "responseModule", type: "address", internalType: "address" },
+                    { name: "disputeModule", type: "address", internalType: "address" },
+                    { name: "resolutionModule", type: "address", internalType: "address" },
+                    { name: "finalityModule", type: "address", internalType: "address" },
+                    { name: "requestModuleData", type: "bytes", internalType: "bytes" },
+                    { name: "responseModuleData", type: "bytes", internalType: "bytes" },
+                    { name: "disputeModuleData", type: "bytes", internalType: "bytes" },
+                    { name: "resolutionModuleData", type: "bytes", internalType: "bytes" },
+                    { name: "finalityModuleData", type: "bytes", internalType: "bytes" },
+                ],
+            },
+            {
+                name: "_dispute",
+                type: "tuple",
+                internalType: "struct IOracle.Dispute",
+                components: [
+                    { name: "disputer", type: "address", internalType: "address" },
+                    { name: "proposer", type: "address", internalType: "address" },
+                    { name: "responseId", type: "bytes32", internalType: "bytes32" },
+                    { name: "requestId", type: "bytes32", internalType: "bytes32" },
+                ],
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "pledgesAgainstDispute",
+        inputs: [
+            { name: "_requestId", type: "bytes32", internalType: "bytes32" },
+            { name: "_pledger", type: "address", internalType: "address" },
+        ],
+        outputs: [{ name: "pledges", type: "uint256", internalType: "uint256" }],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "pledgesForDispute",
+        inputs: [
+            { name: "_requestId", type: "bytes32", internalType: "bytes32" },
+            { name: "_pledger", type: "address", internalType: "address" },
+        ],
+        outputs: [{ name: "pledges", type: "uint256", internalType: "uint256" }],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "settleBondEscalation",
+        inputs: [
+            {
+                name: "_request",
+                type: "tuple",
+                internalType: "struct IOracle.Request",
+                components: [
+                    { name: "nonce", type: "uint96", internalType: "uint96" },
+                    { name: "requester", type: "address", internalType: "address" },
+                    { name: "requestModule", type: "address", internalType: "address" },
+                    { name: "responseModule", type: "address", internalType: "address" },
+                    { name: "disputeModule", type: "address", internalType: "address" },
+                    { name: "resolutionModule", type: "address", internalType: "address" },
+                    { name: "finalityModule", type: "address", internalType: "address" },
+                    { name: "requestModuleData", type: "bytes", internalType: "bytes" },
+                    { name: "responseModuleData", type: "bytes", internalType: "bytes" },
+                    { name: "disputeModuleData", type: "bytes", internalType: "bytes" },
+                    { name: "resolutionModuleData", type: "bytes", internalType: "bytes" },
+                    { name: "finalityModuleData", type: "bytes", internalType: "bytes" },
+                ],
+            },
+            {
+                name: "_response",
+                type: "tuple",
+                internalType: "struct IOracle.Response",
+                components: [
+                    { name: "proposer", type: "address", internalType: "address" },
+                    { name: "requestId", type: "bytes32", internalType: "bytes32" },
+                    { name: "response", type: "bytes", internalType: "bytes" },
+                ],
+            },
+            {
+                name: "_dispute",
+                type: "tuple",
+                internalType: "struct IOracle.Dispute",
+                components: [
+                    { name: "disputer", type: "address", internalType: "address" },
+                    { name: "proposer", type: "address", internalType: "address" },
+                    { name: "responseId", type: "bytes32", internalType: "bytes32" },
+                    { name: "requestId", type: "bytes32", internalType: "bytes32" },
+                ],
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "validateParameters",
+        inputs: [{ name: "_encodedParameters", type: "bytes", internalType: "bytes" }],
+        outputs: [{ name: "_valid", type: "bool", internalType: "bool" }],
+        stateMutability: "pure",
+    },
+    {
+        type: "event",
+        name: "BondEscalationStatusUpdated",
+        inputs: [
+            { name: "_requestId", type: "bytes32", indexed: true, internalType: "bytes32" },
+            { name: "_disputeId", type: "bytes32", indexed: true, internalType: "bytes32" },
+            {
+                name: "_status",
+                type: "uint8",
+                indexed: false,
+                internalType: "enum IBondEscalationModule.BondEscalationStatus",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "DisputeStatusChanged",
+        inputs: [
+            { name: "_disputeId", type: "bytes32", indexed: true, internalType: "bytes32" },
+            {
+                name: "_dispute",
+                type: "tuple",
+                indexed: false,
+                internalType: "struct IOracle.Dispute",
+                components: [
+                    { name: "disputer", type: "address", internalType: "address" },
+                    { name: "proposer", type: "address", internalType: "address" },
+                    { name: "responseId", type: "bytes32", internalType: "bytes32" },
+                    { name: "requestId", type: "bytes32", internalType: "bytes32" },
+                ],
+            },
+            {
+                name: "_status",
+                type: "uint8",
+                indexed: false,
+                internalType: "enum IOracle.DisputeStatus",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "PledgedAgainstDispute",
+        inputs: [
+            { name: "_disputeId", type: "bytes32", indexed: true, internalType: "bytes32" },
+            { name: "_pledger", type: "address", indexed: true, internalType: "address" },
+            { name: "_amount", type: "uint256", indexed: true, internalType: "uint256" },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "PledgedForDispute",
+        inputs: [
+            { name: "_disputeId", type: "bytes32", indexed: true, internalType: "bytes32" },
+            { name: "_pledger", type: "address", indexed: true, internalType: "address" },
+            { name: "_amount", type: "uint256", indexed: true, internalType: "uint256" },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "RequestFinalized",
+        inputs: [
+            { name: "_requestId", type: "bytes32", indexed: true, internalType: "bytes32" },
+            {
+                name: "_response",
+                type: "tuple",
+                indexed: false,
+                internalType: "struct IOracle.Response",
+                components: [
+                    { name: "proposer", type: "address", internalType: "address" },
+                    { name: "requestId", type: "bytes32", internalType: "bytes32" },
+                    { name: "response", type: "bytes", internalType: "bytes" },
+                ],
+            },
+            {
+                name: "_finalizer",
+                type: "address",
+                indexed: false,
+                internalType: "address",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "ResponseDisputed",
+        inputs: [
+            { name: "_requestId", type: "bytes32", indexed: true, internalType: "bytes32" },
+            {
+                name: "_responseId",
+                type: "bytes32",
+                indexed: true,
+                internalType: "bytes32",
+            },
+            { name: "_disputeId", type: "bytes32", indexed: true, internalType: "bytes32" },
+            {
+                name: "_dispute",
+                type: "tuple",
+                indexed: false,
+                internalType: "struct IOracle.Dispute",
+                components: [
+                    { name: "disputer", type: "address", internalType: "address" },
+                    { name: "proposer", type: "address", internalType: "address" },
+                    { name: "responseId", type: "bytes32", internalType: "bytes32" },
+                    { name: "requestId", type: "bytes32", internalType: "bytes32" },
+                ],
+            },
+            {
+                name: "_blockNumber",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+        ],
+        anonymous: false,
+    },
+    { type: "error", name: "BondEscalationModule_BondEscalationCantBeSettled", inputs: [] },
+    { type: "error", name: "BondEscalationModule_BondEscalationNotOver", inputs: [] },
+    { type: "error", name: "BondEscalationModule_BondEscalationOver", inputs: [] },
+    { type: "error", name: "BondEscalationModule_CanOnlySurpassByOnePledge", inputs: [] },
+    {
+        type: "error",
+        name: "BondEscalationModule_CannotBreakTieDuringTyingBuffer",
+        inputs: [],
+    },
+    { type: "error", name: "BondEscalationModule_DisputeDoesNotExist", inputs: [] },
+    { type: "error", name: "BondEscalationModule_DisputeWindowOver", inputs: [] },
+    { type: "error", name: "BondEscalationModule_InvalidDispute", inputs: [] },
+    { type: "error", name: "BondEscalationModule_InvalidEscalationParameters", inputs: [] },
+    {
+        type: "error",
+        name: "BondEscalationModule_MaxNumberOfEscalationsReached",
+        inputs: [],
+    },
+    { type: "error", name: "BondEscalationModule_NotEscalatable", inputs: [] },
+    { type: "error", name: "BondEscalationModule_ShouldBeEscalated", inputs: [] },
+    { type: "error", name: "BondEscalationModule_ZeroValue", inputs: [] },
+    { type: "error", name: "Module_OnlyOracle", inputs: [] },
+    { type: "error", name: "Validator_InvalidDispute", inputs: [] },
+    { type: "error", name: "Validator_InvalidResponse", inputs: [] },
 ] as const;

--- a/packages/automated-dispute/src/services/eboRegistry/commands/addRequest.ts
+++ b/packages/automated-dispute/src/services/eboRegistry/commands/addRequest.ts
@@ -1,5 +1,6 @@
 import { CommandAlreadyRun, CommandNotRun } from "../../../exceptions/index.js";
 import { EboRegistry, EboRegistryCommand } from "../../../interfaces/index.js";
+import { ProtocolProvider } from "../../../providers/index.js";
 import { EboEvent, Request } from "../../../types/index.js";
 
 export class AddRequest implements EboRegistryCommand {
@@ -14,11 +15,20 @@ export class AddRequest implements EboRegistryCommand {
         event: EboEvent<"RequestCreated">,
         registry: EboRegistry,
     ): AddRequest {
+        const eventRequest = event.metadata.request;
         const request: Request = {
             id: event.requestId,
             chainId: event.metadata.chainId,
             epoch: event.metadata.epoch,
             createdAt: event.blockNumber,
+            decodedData: {
+                disputeModuleData: ProtocolProvider.decodeRequestDisputeModuleData(
+                    eventRequest.disputeModuleData,
+                ),
+                responseModuleData: ProtocolProvider.decodeRequestResponseModuleData(
+                    eventRequest.responseModuleData,
+                ),
+            },
             prophetData: event.metadata.request,
             status: "Active",
         };

--- a/packages/automated-dispute/src/services/eboRegistry/commands/addResponse.ts
+++ b/packages/automated-dispute/src/services/eboRegistry/commands/addResponse.ts
@@ -1,6 +1,7 @@
 import { CommandAlreadyRun, CommandNotRun } from "../../../exceptions/index.js";
 import { EboRegistry, EboRegistryCommand } from "../../../interfaces/index.js";
-import { EboEvent, Response } from "../../../types/index.js";
+import { ProtocolProvider } from "../../../providers/index.js";
+import { EboEvent, Response, ResponseBody } from "../../../types/index.js";
 
 export class AddResponse implements EboRegistryCommand {
     private wasRun: boolean = false;
@@ -11,9 +12,15 @@ export class AddResponse implements EboRegistryCommand {
     ) {}
 
     static buildFromEvent(event: EboEvent<"ResponseProposed">, registry: EboRegistry) {
+        const encodedResponse = event.metadata.response.response;
+        const responseBody: ResponseBody = ProtocolProvider.decodeResponse(encodedResponse);
+
         const response: Response = {
             id: event.metadata.responseId,
             createdAt: event.blockNumber,
+            decodedData: {
+                response: responseBody,
+            },
             prophetData: event.metadata.response,
         };
 

--- a/packages/automated-dispute/src/types/events.ts
+++ b/packages/automated-dispute/src/types/events.ts
@@ -1,7 +1,15 @@
 import { Caip2ChainId } from "@ebo-agent/blocknumber/dist/types.js";
-import { Address, Log } from "viem";
+import { Address, Hex, Log } from "viem";
 
-import { Dispute, DisputeStatus, Request, RequestId, Response } from "./prophet.js";
+import {
+    Dispute,
+    DisputeId,
+    DisputeStatus,
+    Request,
+    RequestId,
+    Response,
+    ResponseId,
+} from "./prophet.js";
 
 export type EboEventName =
     | "RequestCreated"
@@ -12,8 +20,8 @@ export type EboEventName =
     | "RequestFinalized";
 
 export interface ResponseProposed {
-    requestId: string;
-    responseId: string;
+    requestId: Hex;
+    responseId: Hex;
     response: Response["prophetData"];
 }
 
@@ -25,13 +33,13 @@ export interface RequestCreated {
 }
 
 export interface ResponseDisputed {
-    responseId: string;
-    disputeId: string;
+    responseId: ResponseId;
+    disputeId: DisputeId;
     dispute: Dispute["prophetData"];
 }
 
 export interface DisputeStatusChanged {
-    disputeId: string;
+    disputeId: DisputeId;
     dispute: Dispute["prophetData"];
     status: DisputeStatus;
     blockNumber: bigint;
@@ -39,14 +47,14 @@ export interface DisputeStatusChanged {
 
 export interface DisputeEscalated {
     caller: Address;
-    disputeId: string;
+    disputeId: DisputeId;
     blockNumber: bigint;
 }
 
 export interface RequestFinalized {
     requestId: RequestId;
-    responseId: string;
-    caller: string;
+    responseId: ResponseId;
+    caller: Address;
     blockNumber: bigint;
 }
 

--- a/packages/automated-dispute/src/types/prophet.ts
+++ b/packages/automated-dispute/src/types/prophet.ts
@@ -1,8 +1,11 @@
 import { Caip2ChainId } from "@ebo-agent/blocknumber/dist/types.js";
 import { NormalizedAddress } from "@ebo-agent/shared";
-import { Address } from "viem";
+import { Address, Hex } from "viem";
 
 export type RequestId = NormalizedAddress;
+export type ResponseId = NormalizedAddress;
+export type DisputeId = NormalizedAddress;
+
 export type RequestStatus = "Active" | "Finalized";
 
 export interface Request {
@@ -12,14 +15,7 @@ export interface Request {
     createdAt: bigint;
     status: RequestStatus;
 
-    prophetData: Readonly<{
-        requester: Address;
-        requestModule: Address;
-        responseModule: Address;
-        disputeModule: Address;
-        resolutionModule: Address;
-        finalityModule: Address;
-        // Modules' data
+    decodedData: {
         responseModuleData: {
             accountingExtension: Address;
             bondToken: Address;
@@ -36,39 +32,58 @@ export interface Request {
             tyingBuffer: bigint;
             disputeWindow: bigint;
         };
+    };
+
+    prophetData: Readonly<{
+        nonce: bigint;
+        requester: Address;
+
+        requestModule: Address;
+        responseModule: Address;
+        disputeModule: Address;
+        resolutionModule: Address;
+        finalityModule: Address;
+
+        requestModuleData: Hex;
+        responseModuleData: Hex;
+        disputeModuleData: Hex;
+        resolutionModuleData: Hex;
+        finalityModuleData: Hex;
     }>;
 }
 
+export type ResponseBody = {
+    chainId: Caip2ChainId;
+    block: bigint;
+    epoch: bigint;
+};
+
 export interface Response {
-    id: string;
+    id: ResponseId;
     createdAt: bigint;
+
+    decodedData: {
+        response: ResponseBody;
+    };
 
     prophetData: Readonly<{
         proposer: Address;
         requestId: RequestId;
-
-        // To be byte-encode when sending it to Prophet
-        response: {
-            chainId: Caip2ChainId; // TODO: Pending on-chain definition on CAIP-2 usage
-            block: bigint;
-            epoch: bigint;
-        };
+        response: Hex;
     }>;
 }
-
-export type ResponseBody = Response["prophetData"]["response"];
 
 export type DisputeStatus = "None" | "Active" | "Escalated" | "Won" | "Lost" | "NoResolution";
 
 export interface Dispute {
-    id: string;
+    id: DisputeId;
     createdAt: bigint;
     status: DisputeStatus;
 
     prophetData: {
         disputer: Address;
         proposer: Address;
-        responseId: string;
+        responseId: ResponseId;
         requestId: RequestId;
     };
 }

--- a/packages/automated-dispute/tests/mocks/eboActor.mocks.ts
+++ b/packages/automated-dispute/tests/mocks/eboActor.mocks.ts
@@ -5,7 +5,7 @@ import { Mutex } from "async-mutex";
 
 import { ProtocolProvider } from "../../src/providers/index.js";
 import { EboActor, EboMemoryRegistry } from "../../src/services/index.js";
-import { Dispute, Request, Response } from "../../src/types/index.js";
+import { Dispute, Request, Response, ResponseBody } from "../../src/types/index.js";
 import {
     DEFAULT_MOCKED_PROTOCOL_CONTRACTS,
     mockedPrivateKey,
@@ -64,17 +64,22 @@ export function buildEboActor(request: Request, logger: ILogger) {
  * @returns a `Response`
  */
 export function buildResponse(request: Request, attributes: Partial<Response> = {}): Response {
+    const responseBody: ResponseBody = {
+        chainId: request.chainId,
+        block: 1n,
+        epoch: request.epoch,
+    };
+
     const baseResponse: Response = {
         id: "0x01",
         createdAt: request.createdAt + 1n,
+        decodedData: {
+            response: responseBody,
+        },
         prophetData: {
             proposer: "0x01",
             requestId: request.id,
-            response: {
-                chainId: request.chainId,
-                block: 1n,
-                epoch: request.epoch,
-            },
+            response: ProtocolProvider.encodeResponse(responseBody),
         },
     };
 

--- a/packages/automated-dispute/tests/services/eboActor.spec.ts
+++ b/packages/automated-dispute/tests/services/eboActor.spec.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { PastEventEnqueueError, RequestMismatch } from "../../src/exceptions/index.js";
+import { ProtocolProvider } from "../../src/providers/index.js";
 import { EboEvent, Request, RequestId } from "../../src/types/index.js";
 import mocks from "../mocks/index.js";
 import { DEFAULT_MOCKED_REQUEST_CREATED_DATA } from "../services/eboActor/fixtures.js";
@@ -22,6 +23,20 @@ describe("EboActor", () => {
             request: request.prophetData,
         },
     };
+
+    beforeEach(() => {
+        vi.spyOn(ProtocolProvider, "decodeRequestDisputeModuleData").mockReturnValue(
+            request.decodedData.disputeModuleData,
+        );
+
+        vi.spyOn(ProtocolProvider, "decodeRequestResponseModuleData").mockReturnValue(
+            request.decodedData.responseModuleData,
+        );
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
 
     describe("enqueue", () => {
         it("enqueues an event", () => {
@@ -248,7 +263,7 @@ describe("EboActor", () => {
     describe("canBeTerminated", () => {
         it("returns false if the request has not been finalized yet", () => {
             const { actor, registry } = mocks.buildEboActor(request, logger);
-            const currentBlockNumber = request.prophetData.responseModuleData.disputeWindow - 1n;
+            const currentBlockNumber = request.decodedData.responseModuleData.disputeWindow - 1n;
 
             vi.spyOn(registry, "getRequest").mockReturnValue(request);
             vi.spyOn(registry, "getResponses").mockReturnValue([]);
@@ -262,7 +277,7 @@ describe("EboActor", () => {
             const response = mocks.buildResponse(request);
             const { actor, registry } = mocks.buildEboActor(request, logger);
             const currentBlockNumber =
-                response.createdAt + request.prophetData.disputeModuleData.disputeWindow - 1n;
+                response.createdAt + request.decodedData.disputeModuleData.disputeWindow - 1n;
 
             vi.spyOn(registry, "getRequest").mockReturnValue(request);
             vi.spyOn(registry, "getResponses").mockReturnValue([response]);
@@ -284,7 +299,7 @@ describe("EboActor", () => {
 
             const { actor, registry } = mocks.buildEboActor(request, logger);
             const currentBlockNumber =
-                response.createdAt + request.prophetData.disputeModuleData.disputeWindow - 1n;
+                response.createdAt + request.decodedData.disputeModuleData.disputeWindow - 1n;
 
             vi.spyOn(registry, "getRequest").mockReturnValue(request);
             vi.spyOn(registry, "getResponses").mockReturnValue([response]);
@@ -307,7 +322,7 @@ describe("EboActor", () => {
             const disputedResponse = mocks.buildResponse(request, { id: "0x01" });
             const undisputedResponse = mocks.buildResponse(request, {
                 id: "0x02",
-                createdAt: request.prophetData.responseModuleData.deadline - 1n,
+                createdAt: request.decodedData.responseModuleData.deadline - 1n,
             });
 
             const escalatedDispute = mocks.buildDispute(request, disputedResponse, {
@@ -317,7 +332,7 @@ describe("EboActor", () => {
             const { actor, registry } = mocks.buildEboActor(request, logger);
             const currentBlockNumber =
                 undisputedResponse.createdAt +
-                request.prophetData.disputeModuleData.disputeWindow +
+                request.decodedData.disputeModuleData.disputeWindow +
                 1n;
 
             vi.spyOn(registry, "getRequest").mockReturnValue(request);
@@ -362,7 +377,7 @@ describe("EboActor", () => {
             const disputedResponse = mocks.buildResponse(request, { id: "0x01" });
             const undisputedResponse = mocks.buildResponse(request, {
                 id: "0x02",
-                createdAt: request.prophetData.responseModuleData.deadline - 1n,
+                createdAt: request.decodedData.responseModuleData.deadline - 1n,
             });
 
             const escalatedDispute = mocks.buildDispute(request, disputedResponse, {
@@ -372,7 +387,7 @@ describe("EboActor", () => {
             const { actor, registry } = mocks.buildEboActor(request, logger);
             const currentBlockNumber =
                 undisputedResponse.createdAt +
-                request.prophetData.disputeModuleData.disputeWindow +
+                request.decodedData.disputeModuleData.disputeWindow +
                 1n;
 
             vi.spyOn(registry, "getRequest").mockReturnValue(request);

--- a/packages/automated-dispute/tests/services/eboActor/fixtures.ts
+++ b/packages/automated-dispute/tests/services/eboActor/fixtures.ts
@@ -1,4 +1,4 @@
-import { Address } from "viem";
+import { Address, Hex } from "viem";
 
 import { Dispute, Request, RequestId, Response } from "../../../src/types/prophet";
 
@@ -31,13 +31,7 @@ export const DEFAULT_MOCKED_REQUEST_CREATED_DATA: Request = {
     epoch: 1n,
     createdAt: 1n,
     status: "Active",
-    prophetData: {
-        disputeModule: "0x01" as Address,
-        finalityModule: "0x02" as Address,
-        requestModule: "0x03" as Address,
-        resolutionModule: "0x04" as Address,
-        responseModule: "0x05" as Address,
-        requester: "0x10" as Address,
+    decodedData: {
         responseModuleData: {
             accountingExtension: "0x01" as Address,
             bondToken: "0x02" as Address,
@@ -54,6 +48,20 @@ export const DEFAULT_MOCKED_REQUEST_CREATED_DATA: Request = {
             maxNumberOfEscalations: 5n,
             tyingBuffer: 1n,
         },
+    },
+    prophetData: {
+        nonce: 1n,
+        disputeModule: "0x01" as Address,
+        finalityModule: "0x02" as Address,
+        requestModule: "0x03" as Address,
+        resolutionModule: "0x04" as Address,
+        responseModule: "0x05" as Address,
+        requester: "0x10" as Address,
+        responseModuleData: "0x11" as Hex, // TODO: use the corresponding encoded data
+        disputeModuleData: "0x12" as Hex, // TODO: use the corresponding encoded data
+        finalityModuleData: "0x13" as Hex,
+        requestModuleData: "0x14" as Hex,
+        resolutionModuleData: "0x15" as Hex,
     },
 };
 

--- a/packages/automated-dispute/tests/services/eboActor/onDisputeStatusChanged.spec.ts
+++ b/packages/automated-dispute/tests/services/eboActor/onDisputeStatusChanged.spec.ts
@@ -1,6 +1,7 @@
 import { ILogger } from "@ebo-agent/shared";
 import { describe, expect, it, vi } from "vitest";
 
+import { ProtocolProvider } from "../../../src/providers/index.ts";
 import { EboEvent } from "../../../src/types/index.js";
 import mocks from "../../mocks/index.ts";
 import { DEFAULT_MOCKED_REQUEST_CREATED_DATA } from "./fixtures.ts";
@@ -70,13 +71,13 @@ describe("onDisputeStatusChanged", () => {
         vi.spyOn(registry, "getDispute").mockReturnValue(dispute);
 
         vi.spyOn(protocolProvider, "getCurrentEpoch").mockResolvedValue({
-            currentEpoch: actorRequest.epoch,
-            currentEpochBlockNumber: actorRequest.createdAt,
-            currentEpochTimestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0)),
+            number: actorRequest.epoch,
+            firstBlockNumber: actorRequest.createdAt,
+            startTimestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0)),
         });
 
         vi.spyOn(blockNumberService, "getEpochBlockNumber").mockResolvedValue(
-            response.prophetData.response.block + 1n,
+            response.decodedData.response.block + 1n,
         );
 
         vi.spyOn(protocolProvider, "getAccountAddress").mockReturnValue(proposerAddress);
@@ -92,11 +93,11 @@ describe("onDisputeStatusChanged", () => {
             expect.objectContaining({
                 proposer: proposerAddress,
                 requestId: actorRequest.id,
-                response: {
+                response: ProtocolProvider.encodeResponse({
                     block: 2n,
                     chainId: actorRequest.chainId,
                     epoch: actorRequest.epoch,
-                },
+                }),
             }),
         );
     });

--- a/packages/automated-dispute/tests/services/eboActor/onLastBlockupdated.spec.ts
+++ b/packages/automated-dispute/tests/services/eboActor/onLastBlockupdated.spec.ts
@@ -11,7 +11,7 @@ describe("EboActor", () => {
     describe("onLastBlockUpdated", () => {
         it("settles all disputes when escalation deadline and tying buffer passed", async () => {
             const request = DEFAULT_MOCKED_REQUEST_CREATED_DATA;
-            const { disputeModuleData } = request.prophetData;
+            const { disputeModuleData } = request.decodedData;
 
             const response = mocks.buildResponse(request, { id: "0x10" });
             const dispute = mocks.buildDispute(request, response, { createdAt: 1n });
@@ -48,7 +48,7 @@ describe("EboActor", () => {
 
         it("escalates dispute if cannot settle", async () => {
             const request = DEFAULT_MOCKED_REQUEST_CREATED_DATA;
-            const { disputeModuleData } = request.prophetData;
+            const { disputeModuleData } = request.decodedData;
 
             const response = mocks.buildResponse(request, { id: "0x10" });
             const dispute = mocks.buildDispute(request, response, { createdAt: 1n });
@@ -100,7 +100,7 @@ describe("EboActor", () => {
 
         it("throws if the dispute has no response in registry", async () => {
             const request = DEFAULT_MOCKED_REQUEST_CREATED_DATA;
-            const { disputeModuleData } = request.prophetData;
+            const { disputeModuleData } = request.decodedData;
 
             const response = mocks.buildResponse(request, { id: "0x10" });
             const dispute = mocks.buildDispute(request, response, { createdAt: 1n });
@@ -128,7 +128,7 @@ describe("EboActor", () => {
             const request = DEFAULT_MOCKED_REQUEST_CREATED_DATA;
             const response = mocks.buildResponse(request, { id: "0x10" });
 
-            const { responseModuleData } = request.prophetData;
+            const { responseModuleData } = request.decodedData;
             const deadline = responseModuleData.deadline;
 
             const { actor, registry, protocolProvider } = mocks.buildEboActor(request, logger);
@@ -174,7 +174,7 @@ describe("EboActor", () => {
             });
 
             const newBlock =
-                secondResponse.createdAt + request.prophetData.responseModuleData.disputeWindow;
+                secondResponse.createdAt + request.decodedData.responseModuleData.disputeWindow;
 
             await actor.onLastBlockUpdated(newBlock + 1n);
 

--- a/packages/automated-dispute/tests/services/eboActor/onResponseDisputed.spec.ts
+++ b/packages/automated-dispute/tests/services/eboActor/onResponseDisputed.spec.ts
@@ -39,13 +39,13 @@ describe("onResponseDisputed", () => {
         vi.spyOn(registry, "getResponse").mockReturnValue(response);
 
         vi.spyOn(protocolProvider, "getCurrentEpoch").mockResolvedValue({
-            currentEpoch: actorRequest.epoch,
-            currentEpochBlockNumber: response.prophetData.response.block,
-            currentEpochTimestamp: BigInt(Date.UTC(2024, 1, 1, 1, 0, 0, 0)),
+            number: actorRequest.epoch,
+            firstBlockNumber: response.decodedData.response.block,
+            startTimestamp: BigInt(Date.UTC(2024, 1, 1, 1, 0, 0, 0)),
         });
 
         vi.spyOn(blockNumberService, "getEpochBlockNumber").mockResolvedValue(
-            response.prophetData.response.block + 1n,
+            response.decodedData.response.block + 1n,
         );
 
         const mockPledgeForDispute = vi.spyOn(protocolProvider, "pledgeForDispute");
@@ -67,13 +67,13 @@ describe("onResponseDisputed", () => {
         vi.spyOn(registry, "getResponse").mockReturnValue(response);
 
         vi.spyOn(protocolProvider, "getCurrentEpoch").mockResolvedValue({
-            currentEpoch: actorRequest.epoch,
-            currentEpochBlockNumber: response.prophetData.response.block,
-            currentEpochTimestamp: BigInt(Date.UTC(2024, 1, 1, 1, 0, 0, 0)),
+            number: actorRequest.epoch,
+            firstBlockNumber: response.decodedData.response.block,
+            startTimestamp: BigInt(Date.UTC(2024, 1, 1, 1, 0, 0, 0)),
         });
 
         vi.spyOn(blockNumberService, "getEpochBlockNumber").mockResolvedValue(
-            response.prophetData.response.block,
+            response.decodedData.response.block,
         );
 
         const mockPledgeAgainstDispute = vi.spyOn(protocolProvider, "pledgeAgainstDispute");
@@ -95,13 +95,13 @@ describe("onResponseDisputed", () => {
         vi.spyOn(registry, "getResponse").mockReturnValue(response);
 
         vi.spyOn(protocolProvider, "getCurrentEpoch").mockResolvedValue({
-            currentEpoch: actorRequest.epoch,
-            currentEpochBlockNumber: response.prophetData.response.block,
-            currentEpochTimestamp: BigInt(Date.UTC(2024, 1, 1, 1, 0, 0, 0)),
+            number: actorRequest.epoch,
+            firstBlockNumber: response.decodedData.response.block,
+            startTimestamp: BigInt(Date.UTC(2024, 1, 1, 1, 0, 0, 0)),
         });
 
         vi.spyOn(blockNumberService, "getEpochBlockNumber").mockResolvedValue(
-            response.prophetData.response.block,
+            response.decodedData.response.block,
         );
 
         vi.spyOn(protocolProvider, "pledgeAgainstDispute").mockResolvedValue();

--- a/packages/automated-dispute/tests/services/eboMemoryRegistry/commands/addRequest.spec.ts
+++ b/packages/automated-dispute/tests/services/eboMemoryRegistry/commands/addRequest.spec.ts
@@ -1,7 +1,9 @@
+import { afterEach } from "node:test";
 import { beforeEach, describe, expect, it, Mock, vi } from "vitest";
 
 import { CommandAlreadyRun, CommandNotRun } from "../../../../src/exceptions/index.js";
 import { EboRegistry } from "../../../../src/interfaces/index.js";
+import { ProtocolProvider } from "../../../../src/providers/protocolProvider.js";
 import { AddRequest } from "../../../../src/services/index.js";
 import { EboEvent } from "../../../../src/types/index.js";
 import { DEFAULT_MOCKED_REQUEST_CREATED_DATA } from "../../../services/eboActor/fixtures.js";
@@ -28,6 +30,18 @@ describe("AddRequest", () => {
             addRequest: vi.fn(),
             removeRequest: vi.fn(),
         } as unknown as EboRegistry;
+
+        vi.spyOn(ProtocolProvider, "decodeRequestDisputeModuleData").mockReturnValue(
+            request.decodedData.disputeModuleData,
+        );
+
+        vi.spyOn(ProtocolProvider, "decodeRequestResponseModuleData").mockReturnValue(
+            request.decodedData.responseModuleData,
+        );
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
     });
 
     describe("run", () => {

--- a/packages/automated-dispute/tests/services/protocolProvider.spec.ts
+++ b/packages/automated-dispute/tests/services/protocolProvider.spec.ts
@@ -5,6 +5,7 @@ import {
     fallback,
     getContract,
     http,
+    isHex,
     WaitForTransactionReceiptTimeoutError,
 } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
@@ -23,7 +24,7 @@ import {
     TransactionExecutionError,
 } from "../../src/exceptions/index.js";
 import { ProtocolProvider } from "../../src/providers/index.js";
-import { ProtocolContractsAddresses } from "../../src/types/index.js";
+import { ProtocolContractsAddresses, Response } from "../../src/types/index.js";
 import {
     DEFAULT_MOCKED_DISPUTE_DATA,
     DEFAULT_MOCKED_REQUEST_CREATED_DATA,
@@ -175,6 +176,32 @@ describe("ProtocolProvider", () => {
             ).toThrowError(RpcUrlsEmpty);
         });
     });
+
+    describe("encodeResponse", () => {
+        const response: Response["decodedData"]["response"] = {
+            chainId: "eip155:1",
+            block: 1n,
+            epoch: 1n,
+        };
+
+        it("generates a hex string with the response encoded", () => {
+            const encodedResponse = ProtocolProvider.encodeResponse(response);
+
+            expect(encodedResponse).toSatisfy((bytes) => isHex(bytes));
+        });
+
+        it("is able to decode encoded data correctly", () => {
+            const encodedResponse = ProtocolProvider.encodeResponse(response);
+            const decodedResponse = ProtocolProvider.decodeResponse(encodedResponse);
+
+            expect(decodedResponse).toEqual(response);
+        });
+    });
+
+    // TODO: whenever we manage to create an actual Request on-chain we can use it
+    //  to feed an encoded Request here for testing
+    describe.todo("decodeRequestResponseModuleData");
+    describe.todo("decodeRequestDisputeModuleData");
 
     describe("getCurrentEpoch", () => {
         it("returns currentEpoch and currentEpochBlock successfully", async () => {

--- a/packages/blocknumber/src/index.ts
+++ b/packages/blocknumber/src/index.ts
@@ -1,1 +1,3 @@
+export { InvalidChainId } from "./exceptions/index.js";
 export * from "./services/index.js";
+export * from "./utils/index.js";

--- a/packages/blocknumber/src/utils/caip/caip2Utils.ts
+++ b/packages/blocknumber/src/utils/caip/caip2Utils.ts
@@ -35,6 +35,16 @@ export class Caip2Utils {
         return true;
     }
 
+    public static isCaip2ChainId(chainId: string): chainId is Caip2ChainId {
+        try {
+            this.validateChainId(chainId);
+
+            return true;
+        } catch (err) {
+            return false;
+        }
+    }
+
     public static getNamespace(chainId: string | Caip2ChainId) {
         this.validateChainId(chainId);
 


### PR DESCRIPTION
# 🤖 Linear

Closes GRT-181

## Description
Replace structs being used before inside `prophetData` object with proper `bytes` properties and add a `decodedData` property within each Prophet entity type to be able to access the decoded data easily.

Most of the action happens within `ProtocolProvider` class with the new encoding/decoding static methods; the rest is just swapping `entity.prophetData.property` with `entity.decodedData.property`.