### PR TITLE
fix: use timestamps for prophet logic

### DIFF
--- a/packages/automated-dispute/src/interfaces/protocolProvider.ts
+++ b/packages/automated-dispute/src/interfaces/protocolProvider.ts
@@ -1,5 +1,5 @@
 import { Caip2ChainId } from "@ebo-agent/blocknumber";
-import { Address } from "viem";
+import { Address, Block } from "viem";
 
 import type { Dispute, EboEvent, EboEventName, Epoch, Request, Response } from "../types/index.js";
 import { ProtocolContractsNames } from "../constants.js";
@@ -19,11 +19,11 @@ export interface IReadProvider {
     getCurrentEpoch(): Promise<Epoch>;
 
     /**
-     * Gets the last finalized block number.
+     * Gets the last finalized block.
      *
-     * @returns A promise that resolves with the block number of the last finalized block.
+     * @returns A promise that resolves with the last finalized block.
      */
-    getLastFinalizedBlock(): Promise<bigint>;
+    getLastFinalizedBlock(): Promise<Block<bigint, boolean, "finalized">>;
 
     /**
      * Retrieves events from the protocol within a specified block range.

--- a/packages/automated-dispute/src/providers/protocolProvider.ts
+++ b/packages/automated-dispute/src/providers/protocolProvider.ts
@@ -1,5 +1,5 @@
 import { Caip2ChainId } from "@ebo-agent/blocknumber/src/index.js";
-import { Timestamp } from "@ebo-agent/shared";
+import { UnixTimestamp } from "@ebo-agent/shared";
 import {
     Address,
     BaseError,
@@ -264,7 +264,7 @@ export class ProtocolProvider implements IProtocolProvider {
         return {
             number: epoch,
             firstBlockNumber: epochFirstBlockNumber,
-            startTimestamp: epochFirstBlock.timestamp as Timestamp,
+            startTimestamp: epochFirstBlock.timestamp as UnixTimestamp,
         };
     }
 

--- a/packages/automated-dispute/src/services/eboProcessor.ts
+++ b/packages/automated-dispute/src/services/eboProcessor.ts
@@ -1,7 +1,8 @@
 import { isNativeError } from "util/types";
 import { BlockNumberService } from "@ebo-agent/blocknumber";
 import { Caip2ChainId } from "@ebo-agent/blocknumber/src/index.js";
-import { Address, EBO_SUPPORTED_CHAIN_IDS, ILogger } from "@ebo-agent/shared";
+import { Address, EBO_SUPPORTED_CHAIN_IDS, ILogger, Timestamp } from "@ebo-agent/shared";
+import { Block } from "viem";
 
 import { PendingModulesApproval, ProcessorAlreadyStarted } from "../exceptions/index.js";
 import { isRequestCreatedEvent } from "../guards.js";
@@ -108,7 +109,7 @@ export class EboProcessor {
             }
 
             const lastBlock = await this.getLastFinalizedBlock();
-            const events = await this.getEvents(this.lastCheckedBlock, lastBlock);
+            const events = await this.getEvents(this.lastCheckedBlock, lastBlock.number);
 
             const eventsByRequestId = this.groupEventsByRequest(events);
             const synchableRequests = this.calculateSynchableRequests([
@@ -135,7 +136,7 @@ export class EboProcessor {
 
             this.createMissingRequests(currentEpoch.number);
 
-            this.lastCheckedBlock = lastBlock;
+            this.lastCheckedBlock = lastBlock.number;
         } catch (err) {
             if (isNativeError(err)) {
                 this.logger.error(`Sync failed: ` + `${err.message}\n\n` + `${err.stack}`);
@@ -167,7 +168,7 @@ export class EboProcessor {
      *
      * @returns the last finalized block
      */
-    private async getLastFinalizedBlock(): Promise<bigint> {
+    private async getLastFinalizedBlock(): Promise<Block<bigint, boolean, "finalized">> {
         this.logger.info("Fetching last finalized block...");
 
         const lastBlock = await this.protocolProvider.getLastFinalizedBlock();
@@ -240,7 +241,7 @@ export class EboProcessor {
         requestId: RequestId,
         events: EboEventStream,
         currentEpoch: Epoch["number"],
-        lastBlock: bigint,
+        lastBlock: Block<bigint, boolean, "finalized">,
     ) {
         const firstEvent = events[0];
         const actor = this.getOrCreateActor(requestId, firstEvent);
@@ -253,10 +254,12 @@ export class EboProcessor {
 
         events.forEach((event) => actor.enqueue(event));
 
-        await actor.processEvents();
-        await actor.onLastBlockUpdated(lastBlock);
+        const lastBlockTimestamp = lastBlock.timestamp as Timestamp;
 
-        if (actor.canBeTerminated(currentEpoch, lastBlock)) {
+        await actor.processEvents();
+        await actor.onLastBlockUpdated(lastBlockTimestamp);
+
+        if (actor.canBeTerminated(currentEpoch, lastBlockTimestamp)) {
             this.terminateActor(requestId);
         }
     }

--- a/packages/automated-dispute/src/services/eboProcessor.ts
+++ b/packages/automated-dispute/src/services/eboProcessor.ts
@@ -1,7 +1,7 @@
 import { isNativeError } from "util/types";
 import { BlockNumberService } from "@ebo-agent/blocknumber";
 import { Caip2ChainId } from "@ebo-agent/blocknumber/src/index.js";
-import { Address, EBO_SUPPORTED_CHAIN_IDS, ILogger, Timestamp } from "@ebo-agent/shared";
+import { Address, EBO_SUPPORTED_CHAIN_IDS, ILogger, UnixTimestamp } from "@ebo-agent/shared";
 import { Block } from "viem";
 
 import { PendingModulesApproval, ProcessorAlreadyStarted } from "../exceptions/index.js";
@@ -254,7 +254,7 @@ export class EboProcessor {
 
         events.forEach((event) => actor.enqueue(event));
 
-        const lastBlockTimestamp = lastBlock.timestamp as Timestamp;
+        const lastBlockTimestamp = lastBlock.timestamp as UnixTimestamp;
 
         await actor.processEvents();
         await actor.onLastBlockUpdated(lastBlockTimestamp);

--- a/packages/automated-dispute/src/services/eboRegistry/commands/addDispute.ts
+++ b/packages/automated-dispute/src/services/eboRegistry/commands/addDispute.ts
@@ -16,7 +16,11 @@ export class AddDispute implements EboRegistryCommand {
     ): AddDispute {
         const dispute: Dispute = {
             id: event.metadata.disputeId,
-            createdAt: event.blockNumber,
+            createdAt: {
+                timestamp: event.timestamp,
+                blockNumber: event.blockNumber,
+                logIndex: event.logIndex,
+            },
             status: "Active",
             prophetData: event.metadata.dispute,
         };

--- a/packages/automated-dispute/src/services/eboRegistry/commands/addRequest.ts
+++ b/packages/automated-dispute/src/services/eboRegistry/commands/addRequest.ts
@@ -20,7 +20,11 @@ export class AddRequest implements EboRegistryCommand {
             id: event.requestId,
             chainId: event.metadata.chainId,
             epoch: event.metadata.epoch,
-            createdAt: event.blockNumber,
+            createdAt: {
+                timestamp: event.timestamp,
+                blockNumber: event.blockNumber,
+                logIndex: event.logIndex,
+            },
             decodedData: {
                 disputeModuleData: ProtocolProvider.decodeRequestDisputeModuleData(
                     eventRequest.disputeModuleData,

--- a/packages/automated-dispute/src/services/eboRegistry/commands/addResponse.ts
+++ b/packages/automated-dispute/src/services/eboRegistry/commands/addResponse.ts
@@ -19,7 +19,11 @@ export class AddResponse implements EboRegistryCommand {
 
         const response: Response = {
             id: Address.normalize(event.metadata.responseId) as ResponseId,
-            createdAt: event.blockNumber,
+            createdAt: {
+                timestamp: event.timestamp,
+                blockNumber: event.blockNumber,
+                logIndex: event.logIndex,
+            },
             decodedData: {
                 response: responseBody,
             },

--- a/packages/automated-dispute/src/types/epochs.ts
+++ b/packages/automated-dispute/src/types/epochs.ts
@@ -1,4 +1,4 @@
-import { Timestamp } from "@ebo-agent/shared";
+import { UnixTimestamp } from "@ebo-agent/shared";
 
 /**
  * Type representing an epoch's data.
@@ -10,5 +10,5 @@ import { Timestamp } from "@ebo-agent/shared";
 export type Epoch = {
     number: bigint;
     firstBlockNumber: bigint;
-    startTimestamp: Timestamp;
+    startTimestamp: UnixTimestamp;
 };

--- a/packages/automated-dispute/src/types/events.ts
+++ b/packages/automated-dispute/src/types/events.ts
@@ -1,4 +1,5 @@
 import { Caip2ChainId } from "@ebo-agent/blocknumber/src/index.js";
+import { Timestamp } from "@ebo-agent/shared";
 import { Address, Hex, Log } from "viem";
 
 import {
@@ -74,8 +75,12 @@ export type EboEventData<E extends EboEventName> = E extends "RequestCreated"
 
 export type EboEvent<T extends EboEventName> = {
     name: T;
+    /** Block's number this event was logged on */
     blockNumber: bigint;
+    /** Log index relative to the block this event was logged on */
     logIndex: number;
+    /** Block's timestamp this event was logged on */
+    timestamp: Timestamp;
     rawLog?: Log;
     requestId: RequestId; // Field to use to route events to actors
     metadata: EboEventData<T>;

--- a/packages/automated-dispute/src/types/events.ts
+++ b/packages/automated-dispute/src/types/events.ts
@@ -1,5 +1,5 @@
 import { Caip2ChainId } from "@ebo-agent/blocknumber/src/index.js";
-import { Timestamp } from "@ebo-agent/shared";
+import { UnixTimestamp } from "@ebo-agent/shared";
 import { Address, Hex, Log } from "viem";
 
 import {
@@ -80,7 +80,7 @@ export type EboEvent<T extends EboEventName> = {
     /** Log index relative to the block this event was logged on */
     logIndex: number;
     /** Block's timestamp this event was logged on */
-    timestamp: Timestamp;
+    timestamp: UnixTimestamp;
     rawLog?: Log;
     requestId: RequestId; // Field to use to route events to actors
     metadata: EboEventData<T>;

--- a/packages/automated-dispute/src/types/prophet.ts
+++ b/packages/automated-dispute/src/types/prophet.ts
@@ -1,5 +1,5 @@
 import { Caip2ChainId } from "@ebo-agent/blocknumber/src/index.js";
-import { Branded, NormalizedAddress, Timestamp } from "@ebo-agent/shared";
+import { Branded, NormalizedAddress, UnixTimestamp } from "@ebo-agent/shared";
 import { Address, Hex } from "viem";
 
 export type RequestId = Branded<NormalizedAddress, "RequestId">;
@@ -14,7 +14,7 @@ export interface Request {
     epoch: bigint;
     createdAt: {
         /** Timestamp of the block the request was created on */
-        timestamp: Timestamp;
+        timestamp: UnixTimestamp;
         blockNumber: bigint;
         logIndex: number;
     };
@@ -65,7 +65,7 @@ export interface Response {
     id: ResponseId;
     createdAt: {
         /** Timestamp of the block the response was created on */
-        timestamp: Timestamp;
+        timestamp: UnixTimestamp;
         blockNumber: bigint;
         logIndex: number;
     };
@@ -87,7 +87,7 @@ export interface Dispute {
     id: DisputeId;
     createdAt: {
         /** Timestamp of the block the dispute was created on */
-        timestamp: Timestamp;
+        timestamp: UnixTimestamp;
         blockNumber: bigint;
         logIndex: number;
     };

--- a/packages/automated-dispute/src/types/prophet.ts
+++ b/packages/automated-dispute/src/types/prophet.ts
@@ -1,5 +1,5 @@
 import { Caip2ChainId } from "@ebo-agent/blocknumber/src/index.js";
-import { Branded, NormalizedAddress } from "@ebo-agent/shared";
+import { Branded, NormalizedAddress, Timestamp } from "@ebo-agent/shared";
 import { Address, Hex } from "viem";
 
 export type RequestId = Branded<NormalizedAddress, "RequestId">;
@@ -12,7 +12,12 @@ export interface Request {
     id: RequestId;
     chainId: Caip2ChainId;
     epoch: bigint;
-    createdAt: bigint;
+    createdAt: {
+        /** Timestamp of the block the request was created on */
+        timestamp: Timestamp;
+        blockNumber: bigint;
+        logIndex: number;
+    };
     status: RequestStatus;
 
     decodedData: {
@@ -58,7 +63,12 @@ export type ResponseBody = {
 
 export interface Response {
     id: ResponseId;
-    createdAt: bigint;
+    createdAt: {
+        /** Timestamp of the block the response was created on */
+        timestamp: Timestamp;
+        blockNumber: bigint;
+        logIndex: number;
+    };
 
     decodedData: {
         response: ResponseBody;
@@ -75,7 +85,12 @@ export type DisputeStatus = "None" | "Active" | "Escalated" | "Won" | "Lost" | "
 
 export interface Dispute {
     id: DisputeId;
-    createdAt: bigint;
+    createdAt: {
+        /** Timestamp of the block the dispute was created on */
+        timestamp: Timestamp;
+        blockNumber: bigint;
+        logIndex: number;
+    };
     status: DisputeStatus;
 
     prophetData: {

--- a/packages/automated-dispute/tests/mocks/eboActor.mocks.ts
+++ b/packages/automated-dispute/tests/mocks/eboActor.mocks.ts
@@ -1,5 +1,5 @@
 import { BlockNumberService, Caip2ChainId } from "@ebo-agent/blocknumber";
-import { ILogger, Timestamp } from "@ebo-agent/shared";
+import { ILogger, UnixTimestamp } from "@ebo-agent/shared";
 import { Mutex } from "async-mutex";
 import { Block } from "viem";
 import { vi } from "vitest";
@@ -51,13 +51,13 @@ export function buildEboActor(request: Request, logger: ILogger) {
     vi.spyOn(protocolProvider, "getCurrentEpoch").mockResolvedValue({
         number: BigInt(1),
         firstBlockNumber: BigInt(100),
-        startTimestamp: BigInt(Date.now()) as Timestamp,
+        startTimestamp: BigInt(Date.now()) as UnixTimestamp,
     });
     vi.spyOn(protocolProvider, "proposeResponse").mockResolvedValue(undefined);
     vi.spyOn(protocolProvider, "disputeResponse").mockResolvedValue(undefined);
     vi.spyOn(protocolProvider, "getLastFinalizedBlock").mockResolvedValue({
         number: BigInt(1),
-        timestamp: BigInt(Date.now()) as Timestamp,
+        timestamp: BigInt(Date.now()) as UnixTimestamp,
     } as unknown as Block<bigint, false, "finalized">);
 
     const blockNumberRpcUrls = new Map<Caip2ChainId, string[]>([
@@ -118,7 +118,7 @@ export function buildResponse(request: Request, attributes: Partial<Response> = 
     const baseResponse: Response = {
         id: "0x0111111111111111111111111111111111111111" as ResponseId,
         createdAt: {
-            timestamp: (request.createdAt.timestamp + 1n) as Timestamp,
+            timestamp: (request.createdAt.timestamp + 1n) as UnixTimestamp,
             blockNumber: request.createdAt.blockNumber + 1n,
             logIndex: request.createdAt.logIndex + 1,
         },
@@ -147,7 +147,7 @@ export function buildDispute(
         id: "0x01" as DisputeId,
         status: "Active",
         createdAt: {
-            timestamp: (response.createdAt.timestamp + 1n) as Timestamp,
+            timestamp: (response.createdAt.timestamp + 1n) as UnixTimestamp,
             blockNumber: response.createdAt.blockNumber + 1n,
             logIndex: response.createdAt.logIndex + 1,
         },

--- a/packages/automated-dispute/tests/services/eboActor.spec.ts
+++ b/packages/automated-dispute/tests/services/eboActor.spec.ts
@@ -1,4 +1,4 @@
-import { Timestamp } from "@ebo-agent/shared";
+import { UnixTimestamp } from "@ebo-agent/shared";
 import { Abi, ContractFunctionRevertedError, encodeErrorResult } from "viem";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -23,7 +23,7 @@ describe("EboActor", () => {
         name: "RequestCreated",
         blockNumber: 2n,
         logIndex: 1,
-        timestamp: BigInt(Date.UTC(2024, 0, 1, 0, 0, 0) / 1000) as Timestamp,
+        timestamp: BigInt(Date.UTC(2024, 0, 1, 0, 0, 0) / 1000) as UnixTimestamp,
         requestId: request.id,
         metadata: {
             chainId: request.chainId,
@@ -205,7 +205,7 @@ describe("EboActor", () => {
                 name: "ResponseProposed",
                 blockNumber: firstEvent.blockNumber + 1n,
                 logIndex: 1,
-                timestamp: BigInt(Date.UTC(2024, 0, 1, 0, 0, 0) / 1000) as Timestamp,
+                timestamp: BigInt(Date.UTC(2024, 0, 1, 0, 0, 0) / 1000) as UnixTimestamp,
                 requestId: firstEvent.requestId,
                 metadata: {
                     requestId: firstEvent.requestId,
@@ -281,7 +281,10 @@ describe("EboActor", () => {
             vi.spyOn(registry, "getResponses").mockReturnValue([]);
 
             expect(
-                actor.canBeTerminated(actor.actorRequest.epoch + 1n, blockTimestamp as Timestamp),
+                actor.canBeTerminated(
+                    actor.actorRequest.epoch + 1n,
+                    blockTimestamp as UnixTimestamp,
+                ),
             ).toBe(false);
         });
 
@@ -298,7 +301,10 @@ describe("EboActor", () => {
             vi.spyOn(registry, "getResponseDispute").mockReturnValue(undefined);
 
             expect(
-                actor.canBeTerminated(actor.actorRequest.epoch + 1n, blockTimestamp as Timestamp),
+                actor.canBeTerminated(
+                    actor.actorRequest.epoch + 1n,
+                    blockTimestamp as UnixTimestamp,
+                ),
             ).toBe(false);
         });
 
@@ -323,7 +329,7 @@ describe("EboActor", () => {
 
             const canBeTerminated = actor.canBeTerminated(
                 actor.actorRequest.epoch + 1n,
-                blockTimestamp as Timestamp,
+                blockTimestamp as UnixTimestamp,
             );
 
             expect(canBeTerminated).toBe(false);
@@ -339,7 +345,8 @@ describe("EboActor", () => {
             const undisputedResponse = mocks.buildResponse(request, {
                 id: "0x02" as ResponseId,
                 createdAt: {
-                    timestamp: (request.decodedData.responseModuleData.deadline - 1n) as Timestamp,
+                    timestamp: (request.decodedData.responseModuleData.deadline -
+                        1n) as UnixTimestamp,
                     blockNumber: request.createdAt.blockNumber + 1n,
                     logIndex: 0,
                 },
@@ -374,12 +381,12 @@ describe("EboActor", () => {
 
             const canBeTerminatedDuringCurrentEpoch = actor.canBeTerminated(
                 actor.actorRequest.epoch,
-                lastBlockTimestamp as Timestamp,
+                lastBlockTimestamp as UnixTimestamp,
             );
 
             const canBeTerminatedDuringNextEpoch = actor.canBeTerminated(
                 actor.actorRequest.epoch + 1n,
-                lastBlockTimestamp as Timestamp,
+                lastBlockTimestamp as UnixTimestamp,
             );
 
             expect(canBeTerminatedDuringCurrentEpoch).toBe(false);
@@ -398,7 +405,8 @@ describe("EboActor", () => {
             const undisputedResponse = mocks.buildResponse(request, {
                 id: "0x02" as ResponseId,
                 createdAt: {
-                    timestamp: (request.decodedData.responseModuleData.deadline - 1n) as Timestamp,
+                    timestamp: (request.decodedData.responseModuleData.deadline -
+                        1n) as UnixTimestamp,
                     blockNumber: request.createdAt.blockNumber + 1n,
                     logIndex: 0,
                 },
@@ -433,7 +441,7 @@ describe("EboActor", () => {
 
             const canBeTerminated = actor.canBeTerminated(
                 actor.actorRequest.epoch + 1n,
-                lastBlockTimestamp as Timestamp,
+                lastBlockTimestamp as UnixTimestamp,
             );
 
             expect(canBeTerminated).toBe(true);
@@ -447,7 +455,7 @@ describe("EboActor", () => {
                 name: "RequestCreated",
                 blockNumber: 1n,
                 logIndex: 0,
-                timestamp: BigInt(Date.UTC(2024, 0, 1, 0, 0, 0) / 1000) as Timestamp,
+                timestamp: BigInt(Date.UTC(2024, 0, 1, 0, 0, 0) / 1000) as UnixTimestamp,
                 requestId: request.id,
                 metadata: {
                     chainId: request.chainId,

--- a/packages/automated-dispute/tests/services/eboActor/fixtures.ts
+++ b/packages/automated-dispute/tests/services/eboActor/fixtures.ts
@@ -1,3 +1,4 @@
+import { Timestamp } from "@ebo-agent/shared";
 import { Address, Hex } from "viem";
 
 import { ProtocolContractsAddresses } from "../../../src/interfaces";
@@ -41,7 +42,11 @@ export const DEFAULT_MOCKED_REQUEST_CREATED_DATA: Request = {
     id: "0x01" as RequestId,
     chainId: "eip155:1",
     epoch: 1n,
-    createdAt: 1n,
+    createdAt: {
+        timestamp: BigInt(Date.UTC(2024, 0, 1, 0, 0, 0, 0) / 1000) as Timestamp,
+        blockNumber: 1n,
+        logIndex: 0,
+    },
     status: "Active",
     decodedData: {
         responseModuleData: {

--- a/packages/automated-dispute/tests/services/eboActor/fixtures.ts
+++ b/packages/automated-dispute/tests/services/eboActor/fixtures.ts
@@ -1,4 +1,4 @@
-import { Timestamp } from "@ebo-agent/shared";
+import { UnixTimestamp } from "@ebo-agent/shared";
 import { Address, Hex } from "viem";
 
 import { ProtocolContractsAddresses } from "../../../src/interfaces";
@@ -43,7 +43,7 @@ export const DEFAULT_MOCKED_REQUEST_CREATED_DATA: Request = {
     chainId: "eip155:1",
     epoch: 1n,
     createdAt: {
-        timestamp: BigInt(Date.UTC(2024, 0, 1, 0, 0, 0, 0) / 1000) as Timestamp,
+        timestamp: BigInt(Date.UTC(2024, 0, 1, 0, 0, 0, 0) / 1000) as UnixTimestamp,
         blockNumber: 1n,
         logIndex: 0,
     },

--- a/packages/automated-dispute/tests/services/eboActor/onLastBlockupdated.spec.ts
+++ b/packages/automated-dispute/tests/services/eboActor/onLastBlockupdated.spec.ts
@@ -1,4 +1,4 @@
-import { Timestamp } from "@ebo-agent/shared";
+import { UnixTimestamp } from "@ebo-agent/shared";
 import { describe, expect, it, vi } from "vitest";
 
 import { DisputeWithoutResponse } from "../../../src/exceptions/index.js";
@@ -17,7 +17,7 @@ describe("EboActor", () => {
             const response = mocks.buildResponse(request, { id: "0x10" as ResponseId });
             const dispute = mocks.buildDispute(request, response, {
                 createdAt: {
-                    timestamp: 1n as Timestamp,
+                    timestamp: 1n as UnixTimestamp,
                     blockNumber: 1000n,
                     logIndex: 0,
                 },
@@ -44,7 +44,7 @@ describe("EboActor", () => {
 
             const newBlockNumber = disputeDeadline + 1n;
 
-            await actor.onLastBlockUpdated(newBlockNumber as Timestamp);
+            await actor.onLastBlockUpdated(newBlockNumber as UnixTimestamp);
 
             expect(mockSettleDispute).toHaveBeenCalledWith(
                 request.prophetData,
@@ -60,7 +60,7 @@ describe("EboActor", () => {
             const response = mocks.buildResponse(request, { id: "0x10" as ResponseId });
             const dispute = mocks.buildDispute(request, response, {
                 createdAt: {
-                    timestamp: 1n as Timestamp,
+                    timestamp: 1n as UnixTimestamp,
                     blockNumber: 1000n,
                     logIndex: 0,
                 },
@@ -83,7 +83,7 @@ describe("EboActor", () => {
 
             const newBlockNumber = disputeDeadline + 1n;
 
-            await expect(actor.onLastBlockUpdated(newBlockNumber as Timestamp)).rejects.toThrow(
+            await expect(actor.onLastBlockUpdated(newBlockNumber as UnixTimestamp)).rejects.toThrow(
                 settleError,
             );
         });
@@ -95,7 +95,7 @@ describe("EboActor", () => {
             const response = mocks.buildResponse(request, { id: "0x10" as ResponseId });
             const dispute = mocks.buildDispute(request, response, {
                 createdAt: {
-                    timestamp: 1n as Timestamp,
+                    timestamp: 1n as UnixTimestamp,
                     blockNumber: 1000n,
                     logIndex: 0,
                 },
@@ -113,7 +113,7 @@ describe("EboActor", () => {
 
             const newBlockNumber = disputeDeadline + 1n;
 
-            expect(actor.onLastBlockUpdated(newBlockNumber as Timestamp)).rejects.toThrow(
+            expect(actor.onLastBlockUpdated(newBlockNumber as UnixTimestamp)).rejects.toThrow(
                 DisputeWithoutResponse,
             );
         });
@@ -140,7 +140,7 @@ describe("EboActor", () => {
             const newBlockNumber = deadline - 1n;
             const mockFinalize = vi.spyOn(protocolProvider, "finalize");
 
-            await actor.onLastBlockUpdated(newBlockNumber as Timestamp);
+            await actor.onLastBlockUpdated(newBlockNumber as UnixTimestamp);
 
             expect(logger.debug).toBeCalledWith(
                 expect.stringMatching(`Proposal window for request ${request.id} not closed yet.`),
@@ -154,7 +154,7 @@ describe("EboActor", () => {
             const firstResponse = mocks.buildResponse(request, {
                 id: "0x10" as ResponseId,
                 createdAt: {
-                    timestamp: 5n as Timestamp,
+                    timestamp: 5n as UnixTimestamp,
                     blockNumber: 1000n,
                     logIndex: 0,
                 },
@@ -165,7 +165,7 @@ describe("EboActor", () => {
             const secondResponse = mocks.buildResponse(request, {
                 id: "0x11" as ResponseId,
                 createdAt: {
-                    timestamp: 10n as Timestamp,
+                    timestamp: 10n as UnixTimestamp,
                     blockNumber: 1000n,
                     logIndex: 0,
                 },
@@ -187,7 +187,7 @@ describe("EboActor", () => {
                 secondResponse.createdAt.timestamp +
                 request.decodedData.responseModuleData.disputeWindow;
 
-            await actor.onLastBlockUpdated((newBlock + 1n) as Timestamp);
+            await actor.onLastBlockUpdated((newBlock + 1n) as UnixTimestamp);
 
             expect(mockFinalize).toHaveBeenCalledWith(
                 request.prophetData,

--- a/packages/automated-dispute/tests/services/eboActor/onLastBlockupdated.spec.ts
+++ b/packages/automated-dispute/tests/services/eboActor/onLastBlockupdated.spec.ts
@@ -1,3 +1,4 @@
+import { Timestamp } from "@ebo-agent/shared";
 import { describe, expect, it, vi } from "vitest";
 
 import { DisputeWithoutResponse } from "../../../src/exceptions/index.js";
@@ -14,7 +15,13 @@ describe("EboActor", () => {
             const { disputeModuleData } = request.decodedData;
 
             const response = mocks.buildResponse(request, { id: "0x10" as ResponseId });
-            const dispute = mocks.buildDispute(request, response, { createdAt: 1n });
+            const dispute = mocks.buildDispute(request, response, {
+                createdAt: {
+                    timestamp: 1n as Timestamp,
+                    blockNumber: 1000n,
+                    logIndex: 0,
+                },
+            });
             const disputeDeadline =
                 disputeModuleData.bondEscalationDeadline + disputeModuleData.tyingBuffer;
 
@@ -37,7 +44,7 @@ describe("EboActor", () => {
 
             const newBlockNumber = disputeDeadline + 1n;
 
-            await actor.onLastBlockUpdated(newBlockNumber);
+            await actor.onLastBlockUpdated(newBlockNumber as Timestamp);
 
             expect(mockSettleDispute).toHaveBeenCalledWith(
                 request.prophetData,
@@ -51,7 +58,13 @@ describe("EboActor", () => {
             const { disputeModuleData } = request.decodedData;
 
             const response = mocks.buildResponse(request, { id: "0x10" as ResponseId });
-            const dispute = mocks.buildDispute(request, response, { createdAt: 1n });
+            const dispute = mocks.buildDispute(request, response, {
+                createdAt: {
+                    timestamp: 1n as Timestamp,
+                    blockNumber: 1000n,
+                    logIndex: 0,
+                },
+            });
             const disputeDeadline =
                 disputeModuleData.bondEscalationDeadline + disputeModuleData.tyingBuffer;
 
@@ -70,7 +83,9 @@ describe("EboActor", () => {
 
             const newBlockNumber = disputeDeadline + 1n;
 
-            await expect(actor.onLastBlockUpdated(newBlockNumber)).rejects.toThrow(settleError);
+            await expect(actor.onLastBlockUpdated(newBlockNumber as Timestamp)).rejects.toThrow(
+                settleError,
+            );
         });
 
         it("throws if the dispute has no response in registry", async () => {
@@ -78,7 +93,13 @@ describe("EboActor", () => {
             const { disputeModuleData } = request.decodedData;
 
             const response = mocks.buildResponse(request, { id: "0x10" as ResponseId });
-            const dispute = mocks.buildDispute(request, response, { createdAt: 1n });
+            const dispute = mocks.buildDispute(request, response, {
+                createdAt: {
+                    timestamp: 1n as Timestamp,
+                    blockNumber: 1000n,
+                    logIndex: 0,
+                },
+            });
             const disputeDeadline =
                 disputeModuleData.bondEscalationDeadline + disputeModuleData.tyingBuffer;
 
@@ -92,7 +113,7 @@ describe("EboActor", () => {
 
             const newBlockNumber = disputeDeadline + 1n;
 
-            expect(actor.onLastBlockUpdated(newBlockNumber)).rejects.toThrow(
+            expect(actor.onLastBlockUpdated(newBlockNumber as Timestamp)).rejects.toThrow(
                 DisputeWithoutResponse,
             );
         });
@@ -119,7 +140,7 @@ describe("EboActor", () => {
             const newBlockNumber = deadline - 1n;
             const mockFinalize = vi.spyOn(protocolProvider, "finalize");
 
-            await actor.onLastBlockUpdated(newBlockNumber);
+            await actor.onLastBlockUpdated(newBlockNumber as Timestamp);
 
             expect(logger.debug).toBeCalledWith(
                 expect.stringMatching(`Proposal window for request ${request.id} not closed yet.`),
@@ -132,14 +153,22 @@ describe("EboActor", () => {
             const request = DEFAULT_MOCKED_REQUEST_CREATED_DATA;
             const firstResponse = mocks.buildResponse(request, {
                 id: "0x10" as ResponseId,
-                createdAt: 5n,
+                createdAt: {
+                    timestamp: 5n as Timestamp,
+                    blockNumber: 1000n,
+                    logIndex: 0,
+                },
             });
             const firstResponseDispute = mocks.buildDispute(request, firstResponse, {
                 status: "Lost",
             });
             const secondResponse = mocks.buildResponse(request, {
                 id: "0x11" as ResponseId,
-                createdAt: 10n,
+                createdAt: {
+                    timestamp: 10n as Timestamp,
+                    blockNumber: 1000n,
+                    logIndex: 0,
+                },
             });
 
             const { actor, registry, protocolProvider } = mocks.buildEboActor(request, logger);
@@ -155,9 +184,10 @@ describe("EboActor", () => {
             });
 
             const newBlock =
-                secondResponse.createdAt + request.decodedData.responseModuleData.disputeWindow;
+                secondResponse.createdAt.timestamp +
+                request.decodedData.responseModuleData.disputeWindow;
 
-            await actor.onLastBlockUpdated(newBlock + 1n);
+            await actor.onLastBlockUpdated((newBlock + 1n) as Timestamp);
 
             expect(mockFinalize).toHaveBeenCalledWith(
                 request.prophetData,

--- a/packages/automated-dispute/tests/services/eboMemoryRegistry/commands/addResponse.spec.ts
+++ b/packages/automated-dispute/tests/services/eboMemoryRegistry/commands/addResponse.spec.ts
@@ -14,7 +14,8 @@ describe("AddResponse", () => {
     const response = mocks.buildResponse(request);
     const event: EboEvent<"ResponseProposed"> = {
         name: "ResponseProposed",
-        blockNumber: response.createdAt,
+        blockNumber: response.createdAt.blockNumber,
+        timestamp: response.createdAt.timestamp,
         logIndex: 1,
         requestId: request.id,
         metadata: {

--- a/packages/automated-dispute/tests/services/eboProcessor.spec.ts
+++ b/packages/automated-dispute/tests/services/eboProcessor.spec.ts
@@ -1,5 +1,5 @@
 import { BlockNumberService, Caip2ChainId } from "@ebo-agent/blocknumber";
-import { Timestamp } from "@ebo-agent/shared";
+import { UnixTimestamp } from "@ebo-agent/shared";
 import { Block } from "viem";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -59,7 +59,7 @@ describe("EboProcessor", () => {
             const currentEpoch: Epoch = {
                 number: 1n,
                 firstBlockNumber: 1n,
-                startTimestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as Timestamp,
+                startTimestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as UnixTimestamp,
             };
 
             const lastFinalizedBlock = {
@@ -70,7 +70,7 @@ describe("EboProcessor", () => {
                 name: "RequestCreated",
                 blockNumber: 1n,
                 logIndex: 1,
-                timestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as Timestamp,
+                timestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as UnixTimestamp,
                 requestId: request.id,
                 metadata: {
                     requestId: request.id,
@@ -114,7 +114,7 @@ describe("EboProcessor", () => {
             const currentEpoch: Epoch = {
                 number: 1n,
                 firstBlockNumber: 1n,
-                startTimestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as Timestamp,
+                startTimestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as UnixTimestamp,
             };
 
             const request = {
@@ -126,7 +126,7 @@ describe("EboProcessor", () => {
                 name: "RequestCreated",
                 blockNumber: 1n,
                 logIndex: 1,
-                timestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as Timestamp,
+                timestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as UnixTimestamp,
                 requestId: request.id,
                 metadata: {
                     requestId: request.id,
@@ -137,7 +137,7 @@ describe("EboProcessor", () => {
             };
 
             const lastFinalizedBlock = {
-                number: (currentEpoch.firstBlockNumber + 10n) as Timestamp,
+                number: (currentEpoch.firstBlockNumber + 10n) as UnixTimestamp,
             } as unknown as Block<bigint, false, "finalized">;
 
             vi.spyOn(protocolProvider, "getAccountingApprovedModules").mockResolvedValue(
@@ -162,11 +162,11 @@ describe("EboProcessor", () => {
             const currentEpoch: Epoch = {
                 number: 1n,
                 firstBlockNumber: 1n,
-                startTimestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as Timestamp,
+                startTimestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as UnixTimestamp,
             };
 
             const lastFinalizedBlock = {
-                number: (currentEpoch.firstBlockNumber + 10n) as Timestamp,
+                number: (currentEpoch.firstBlockNumber + 10n) as UnixTimestamp,
             } as unknown as Block<bigint, false, "finalized">;
 
             vi.spyOn(protocolProvider, "getAccountingApprovedModules").mockResolvedValue(
@@ -193,7 +193,7 @@ describe("EboProcessor", () => {
             const currentEpoch = {
                 number: 1n,
                 firstBlockNumber: 1n,
-                startTimestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as Timestamp,
+                startTimestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as UnixTimestamp,
             };
 
             const currentBlock = {
@@ -204,7 +204,7 @@ describe("EboProcessor", () => {
                 name: "RequestCreated",
                 blockNumber: 1n,
                 logIndex: 1,
-                timestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as Timestamp,
+                timestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as UnixTimestamp,
                 requestId: request.id,
                 metadata: {
                     requestId: request.id,
@@ -247,7 +247,7 @@ describe("EboProcessor", () => {
             const currentEpoch = {
                 number: 1n,
                 firstBlockNumber: 1n,
-                startTimestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as Timestamp,
+                startTimestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as UnixTimestamp,
             };
 
             const mockProtocolProviderGetEvents = vi
@@ -313,17 +313,17 @@ describe("EboProcessor", () => {
             const currentEpoch = {
                 number: 1n,
                 firstBlockNumber: 1n,
-                startTimestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as Timestamp,
+                startTimestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as UnixTimestamp,
             };
 
             const currentBlock = {
-                number: (currentEpoch.firstBlockNumber + 10n) as Timestamp,
+                number: (currentEpoch.firstBlockNumber + 10n) as UnixTimestamp,
             } as unknown as Block<bigint, false, "finalized">;
 
             const requestCreatedEvent: EboEvent<"RequestCreated"> = {
                 name: "RequestCreated",
                 blockNumber: 6n,
-                timestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as Timestamp,
+                timestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as UnixTimestamp,
                 logIndex: 1,
                 requestId: DEFAULT_MOCKED_REQUEST_CREATED_DATA.id,
                 metadata: {
@@ -363,7 +363,7 @@ describe("EboProcessor", () => {
             const currentEpoch = {
                 number: 1n,
                 firstBlockNumber: 1n,
-                startTimestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as Timestamp,
+                startTimestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as UnixTimestamp,
             };
 
             const currentBlock = {
@@ -384,7 +384,7 @@ describe("EboProcessor", () => {
                     name: "RequestCreated",
                     blockNumber: 6n,
                     logIndex: 1,
-                    timestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as Timestamp,
+                    timestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as UnixTimestamp,
                     requestId: request.id,
                     metadata: {
                         requestId: request.id,
@@ -397,7 +397,7 @@ describe("EboProcessor", () => {
                     name: "ResponseProposed",
                     blockNumber: 7n,
                     logIndex: 1,
-                    timestamp: BigInt(Date.UTC(2024, 1, 2, 0, 0, 0, 0)) as Timestamp,
+                    timestamp: BigInt(Date.UTC(2024, 1, 2, 0, 0, 0, 0)) as UnixTimestamp,
                     requestId: request.id,
                     metadata: {
                         requestId: request.id,
@@ -436,7 +436,7 @@ describe("EboProcessor", () => {
             const currentEpoch = {
                 number: 1n,
                 firstBlockNumber: 1n,
-                startTimestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as Timestamp,
+                startTimestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as UnixTimestamp,
             };
 
             const currentBlock = {
@@ -468,7 +468,7 @@ describe("EboProcessor", () => {
                     name: "ResponseProposed",
                     blockNumber: 7n,
                     logIndex: 1,
-                    timestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as Timestamp,
+                    timestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as UnixTimestamp,
                     requestId: request1.id,
                     metadata: {
                         requestId: request1.id,
@@ -480,7 +480,7 @@ describe("EboProcessor", () => {
                     name: "ResponseProposed",
                     blockNumber: 7n,
                     logIndex: 2,
-                    timestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as Timestamp,
+                    timestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as UnixTimestamp,
                     requestId: request2.id,
                     metadata: {
                         requestId: request2.id,
@@ -537,7 +537,7 @@ describe("EboProcessor", () => {
             const currentEpoch = {
                 number: 1n,
                 firstBlockNumber: 1n,
-                startTimestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as Timestamp,
+                startTimestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as UnixTimestamp,
             };
 
             const lastFinalizedBlock = { number: 1n } as unknown as Block<
@@ -584,7 +584,7 @@ describe("EboProcessor", () => {
             const currentEpoch = {
                 number: 1n,
                 firstBlockNumber: 1n,
-                startTimestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as Timestamp,
+                startTimestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as UnixTimestamp,
             };
 
             const lastFinalizedBlock = {
@@ -627,7 +627,7 @@ describe("EboProcessor", () => {
             const currentEpoch = {
                 number: 1n,
                 firstBlockNumber: 1n,
-                startTimestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as Timestamp,
+                startTimestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as UnixTimestamp,
             };
 
             const lastFinalizedBlock = {
@@ -666,7 +666,7 @@ describe("EboProcessor", () => {
             const currentEpoch = {
                 number: 1n,
                 firstBlockNumber: 1n,
-                startTimestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as Timestamp,
+                startTimestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as UnixTimestamp,
             };
 
             const currentBlock = {

--- a/packages/automated-dispute/tests/services/eboProcessor.spec.ts
+++ b/packages/automated-dispute/tests/services/eboProcessor.spec.ts
@@ -1,4 +1,6 @@
 import { BlockNumberService, Caip2ChainId } from "@ebo-agent/blocknumber";
+import { Timestamp } from "@ebo-agent/shared";
+import { Block } from "viem";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { PendingModulesApproval, ProcessorAlreadyStarted } from "../../src/exceptions/index.js";
@@ -57,13 +59,18 @@ describe("EboProcessor", () => {
             const currentEpoch: Epoch = {
                 number: 1n,
                 firstBlockNumber: 1n,
-                startTimestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)),
+                startTimestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as Timestamp,
             };
+
+            const lastFinalizedBlock = {
+                number: currentEpoch.firstBlockNumber + 10n,
+            } as unknown as Block<bigint, false, "finalized">;
 
             const requestCreatedEvent: EboEvent<"RequestCreated"> = {
                 name: "RequestCreated",
                 blockNumber: 1n,
                 logIndex: 1,
+                timestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as Timestamp,
                 requestId: request.id,
                 metadata: {
                     requestId: request.id,
@@ -78,7 +85,7 @@ describe("EboProcessor", () => {
             );
             vi.spyOn(protocolProvider, "getCurrentEpoch").mockResolvedValue(currentEpoch);
             vi.spyOn(protocolProvider, "getLastFinalizedBlock").mockResolvedValue(
-                currentEpoch.firstBlockNumber + 10n,
+                lastFinalizedBlock,
             );
             vi.spyOn(protocolProvider, "getEvents").mockResolvedValue([requestCreatedEvent]);
 
@@ -107,7 +114,7 @@ describe("EboProcessor", () => {
             const currentEpoch: Epoch = {
                 number: 1n,
                 firstBlockNumber: 1n,
-                startTimestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)),
+                startTimestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as Timestamp,
             };
 
             const request = {
@@ -119,6 +126,7 @@ describe("EboProcessor", () => {
                 name: "RequestCreated",
                 blockNumber: 1n,
                 logIndex: 1,
+                timestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as Timestamp,
                 requestId: request.id,
                 metadata: {
                     requestId: request.id,
@@ -128,12 +136,16 @@ describe("EboProcessor", () => {
                 },
             };
 
+            const lastFinalizedBlock = {
+                number: (currentEpoch.firstBlockNumber + 10n) as Timestamp,
+            } as unknown as Block<bigint, false, "finalized">;
+
             vi.spyOn(protocolProvider, "getAccountingApprovedModules").mockResolvedValue(
                 allModulesApproved,
             );
             vi.spyOn(protocolProvider, "getCurrentEpoch").mockResolvedValue(currentEpoch);
             vi.spyOn(protocolProvider, "getLastFinalizedBlock").mockResolvedValue(
-                currentEpoch.firstBlockNumber + 10n,
+                lastFinalizedBlock,
             );
             vi.spyOn(protocolProvider, "getEvents").mockResolvedValue([requestCreatedEvent]);
 
@@ -150,15 +162,19 @@ describe("EboProcessor", () => {
             const currentEpoch: Epoch = {
                 number: 1n,
                 firstBlockNumber: 1n,
-                startTimestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)),
+                startTimestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as Timestamp,
             };
+
+            const lastFinalizedBlock = {
+                number: (currentEpoch.firstBlockNumber + 10n) as Timestamp,
+            } as unknown as Block<bigint, false, "finalized">;
 
             vi.spyOn(protocolProvider, "getAccountingApprovedModules").mockResolvedValue(
                 allModulesApproved,
             );
             vi.spyOn(protocolProvider, "getCurrentEpoch").mockResolvedValue(currentEpoch);
             vi.spyOn(protocolProvider, "getLastFinalizedBlock").mockResolvedValue(
-                currentEpoch.firstBlockNumber + 10n,
+                lastFinalizedBlock,
             );
             vi.spyOn(protocolProvider, "getEvents").mockResolvedValue([]);
 
@@ -177,15 +193,18 @@ describe("EboProcessor", () => {
             const currentEpoch = {
                 number: 1n,
                 firstBlockNumber: 1n,
-                startTimestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)),
+                startTimestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as Timestamp,
             };
 
-            const currentBlock = currentEpoch.firstBlockNumber + 10n;
+            const currentBlock = {
+                number: currentEpoch.firstBlockNumber + 10n,
+            } as unknown as Block<bigint, false, "finalized">;
 
             const requestCreatedEvent: EboEvent<"RequestCreated"> = {
                 name: "RequestCreated",
                 blockNumber: 1n,
                 logIndex: 1,
+                timestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as Timestamp,
                 requestId: request.id,
                 metadata: {
                     requestId: request.id,
@@ -210,7 +229,10 @@ describe("EboProcessor", () => {
 
             await processor.start(msBetweenChecks);
 
-            expect(mockGetEvents).toHaveBeenCalledWith(currentEpoch.firstBlockNumber, currentBlock);
+            expect(mockGetEvents).toHaveBeenCalledWith(
+                currentEpoch.firstBlockNumber,
+                currentBlock.number,
+            );
         });
 
         it("keeps the last block checked unaltered when something fails during sync", async () => {
@@ -225,7 +247,7 @@ describe("EboProcessor", () => {
             const currentEpoch = {
                 number: 1n,
                 firstBlockNumber: 1n,
-                startTimestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)),
+                startTimestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as Timestamp,
             };
 
             const mockProtocolProviderGetEvents = vi
@@ -241,8 +263,16 @@ describe("EboProcessor", () => {
             );
 
             vi.spyOn(protocolProvider, "getLastFinalizedBlock")
-                .mockResolvedValueOnce(initialCurrentBlock + 10n)
-                .mockResolvedValueOnce(initialCurrentBlock + 20n);
+                .mockResolvedValueOnce({ number: initialCurrentBlock + 10n } as unknown as Block<
+                    bigint,
+                    false,
+                    "finalized"
+                >)
+                .mockResolvedValueOnce({ number: initialCurrentBlock + 20n } as unknown as Block<
+                    bigint,
+                    false,
+                    "finalized"
+                >);
 
             vi.spyOn(protocolProvider, "getCurrentEpoch").mockResolvedValue(currentEpoch);
             vi.spyOn(actorsManager, "createActor").mockReturnValue(actor);
@@ -283,14 +313,17 @@ describe("EboProcessor", () => {
             const currentEpoch = {
                 number: 1n,
                 firstBlockNumber: 1n,
-                startTimestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)),
+                startTimestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as Timestamp,
             };
 
-            const currentBlock = currentEpoch.firstBlockNumber + 10n;
+            const currentBlock = {
+                number: (currentEpoch.firstBlockNumber + 10n) as Timestamp,
+            } as unknown as Block<bigint, false, "finalized">;
 
             const requestCreatedEvent: EboEvent<"RequestCreated"> = {
                 name: "RequestCreated",
                 blockNumber: 6n,
+                timestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as Timestamp,
                 logIndex: 1,
                 requestId: DEFAULT_MOCKED_REQUEST_CREATED_DATA.id,
                 metadata: {
@@ -318,7 +351,7 @@ describe("EboProcessor", () => {
 
             await processor.start(msBetweenChecks);
 
-            expect(mockGetEvents).toHaveBeenCalledWith(mockLastCheckedBlock, currentBlock);
+            expect(mockGetEvents).toHaveBeenCalledWith(mockLastCheckedBlock, currentBlock.number);
         });
 
         it("enqueues and process every new event into the actor", async () => {
@@ -330,10 +363,12 @@ describe("EboProcessor", () => {
             const currentEpoch = {
                 number: 1n,
                 firstBlockNumber: 1n,
-                startTimestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)),
+                startTimestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as Timestamp,
             };
 
-            const currentBlock = currentEpoch.firstBlockNumber + 10n;
+            const currentBlock = {
+                number: currentEpoch.firstBlockNumber + 10n,
+            } as unknown as Block<bigint, false, "finalized">;
 
             vi.spyOn(protocolProvider, "getAccountingApprovedModules").mockResolvedValue(
                 allModulesApproved,
@@ -349,6 +384,7 @@ describe("EboProcessor", () => {
                     name: "RequestCreated",
                     blockNumber: 6n,
                     logIndex: 1,
+                    timestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as Timestamp,
                     requestId: request.id,
                     metadata: {
                         requestId: request.id,
@@ -361,6 +397,7 @@ describe("EboProcessor", () => {
                     name: "ResponseProposed",
                     blockNumber: 7n,
                     logIndex: 1,
+                    timestamp: BigInt(Date.UTC(2024, 1, 2, 0, 0, 0, 0)) as Timestamp,
                     requestId: request.id,
                     metadata: {
                         requestId: request.id,
@@ -399,10 +436,12 @@ describe("EboProcessor", () => {
             const currentEpoch = {
                 number: 1n,
                 firstBlockNumber: 1n,
-                startTimestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)),
+                startTimestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as Timestamp,
             };
 
-            const currentBlock = currentEpoch.firstBlockNumber + 10n;
+            const currentBlock = {
+                number: currentEpoch.firstBlockNumber + 10n,
+            } as unknown as Block<bigint, false, "finalized">;
 
             vi.spyOn(protocolProvider, "getAccountingApprovedModules").mockResolvedValue(
                 allModulesApproved,
@@ -429,6 +468,7 @@ describe("EboProcessor", () => {
                     name: "ResponseProposed",
                     blockNumber: 7n,
                     logIndex: 1,
+                    timestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as Timestamp,
                     requestId: request1.id,
                     metadata: {
                         requestId: request1.id,
@@ -440,6 +480,7 @@ describe("EboProcessor", () => {
                     name: "ResponseProposed",
                     blockNumber: 7n,
                     logIndex: 2,
+                    timestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as Timestamp,
                     requestId: request2.id,
                     metadata: {
                         requestId: request2.id,
@@ -496,14 +537,22 @@ describe("EboProcessor", () => {
             const currentEpoch = {
                 number: 1n,
                 firstBlockNumber: 1n,
-                startTimestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)),
+                startTimestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as Timestamp,
             };
+
+            const lastFinalizedBlock = { number: 1n } as unknown as Block<
+                bigint,
+                false,
+                "finalized"
+            >;
 
             vi.spyOn(protocolProvider, "getAccountingApprovedModules").mockResolvedValue(
                 allModulesApproved,
             );
             vi.spyOn(protocolProvider, "getCurrentEpoch").mockResolvedValue(currentEpoch);
-            vi.spyOn(protocolProvider, "getLastFinalizedBlock").mockResolvedValue(1n);
+            vi.spyOn(protocolProvider, "getLastFinalizedBlock").mockResolvedValue(
+                lastFinalizedBlock,
+            );
             vi.spyOn(protocolProvider, "getEvents").mockResolvedValue([]);
             vi.spyOn(protocolProvider, "getAvailableChains").mockResolvedValue([
                 "eip155:1",
@@ -511,7 +560,7 @@ describe("EboProcessor", () => {
             ]);
 
             vi.spyOn(actorsManager, "getActorsRequests").mockReturnValue([
-                { id: "0x01", chainId: "eip155:1", epoch: currentEpoch.number },
+                { id: "0x01" as RequestId, chainId: "eip155:1", epoch: currentEpoch.number },
             ]);
 
             const mockProtocolProviderCreateRequest = vi
@@ -535,14 +584,20 @@ describe("EboProcessor", () => {
             const currentEpoch = {
                 number: 1n,
                 firstBlockNumber: 1n,
-                startTimestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)),
+                startTimestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as Timestamp,
             };
+
+            const lastFinalizedBlock = {
+                number: 1n,
+            } as unknown as Block<bigint, false, "finalized">;
 
             vi.spyOn(protocolProvider, "getAccountingApprovedModules").mockResolvedValue(
                 allModulesApproved,
             );
             vi.spyOn(protocolProvider, "getCurrentEpoch").mockResolvedValue(currentEpoch);
-            vi.spyOn(protocolProvider, "getLastFinalizedBlock").mockResolvedValue(1n);
+            vi.spyOn(protocolProvider, "getLastFinalizedBlock").mockResolvedValue(
+                lastFinalizedBlock,
+            );
             vi.spyOn(protocolProvider, "getEvents").mockResolvedValue([]);
             vi.spyOn(protocolProvider, "getAvailableChains").mockResolvedValue([
                 "eip155:1",
@@ -550,8 +605,8 @@ describe("EboProcessor", () => {
             ]);
 
             vi.spyOn(actorsManager, "getActorsRequests").mockReturnValue([
-                { id: "0x01", chainId: "eip155:1", epoch: currentEpoch.number },
-                { id: "0x02", chainId: "eip155:42161", epoch: currentEpoch.number },
+                { id: "0x01" as RequestId, chainId: "eip155:1", epoch: currentEpoch.number },
+                { id: "0x02" as RequestId, chainId: "eip155:42161", epoch: currentEpoch.number },
             ]);
 
             const mockProtocolProviderCreateRequest = vi
@@ -570,16 +625,22 @@ describe("EboProcessor", () => {
             );
 
             const currentEpoch = {
-                epoch: 1n,
+                number: 1n,
                 firstBlockNumber: 1n,
-                startTimestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)),
+                startTimestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as Timestamp,
             };
+
+            const lastFinalizedBlock = {
+                number: 1n,
+            } as unknown as Block<bigint, false, "finalized">;
 
             vi.spyOn(protocolProvider, "getAccountingApprovedModules").mockResolvedValue(
                 allModulesApproved,
             );
             vi.spyOn(protocolProvider, "getCurrentEpoch").mockResolvedValue(currentEpoch);
-            vi.spyOn(protocolProvider, "getLastFinalizedBlock").mockResolvedValue(1n);
+            vi.spyOn(protocolProvider, "getLastFinalizedBlock").mockResolvedValue(
+                lastFinalizedBlock,
+            );
             vi.spyOn(protocolProvider, "getEvents").mockResolvedValue([]);
             vi.spyOn(protocolProvider, "getAvailableChains").mockResolvedValue([
                 "eip155:1",
@@ -588,7 +649,7 @@ describe("EboProcessor", () => {
             vi.spyOn(protocolProvider, "createRequest").mockImplementation(() => Promise.reject());
 
             vi.spyOn(actorsManager, "getActorsRequests").mockReturnValue([
-                { id: "0x01", chainId: "eip155:1", epoch: currentEpoch.epoch },
+                { id: "0x01" as RequestId, chainId: "eip155:1", epoch: currentEpoch.number },
             ]);
 
             expect(processor.start()).resolves.not.toThrow();
@@ -603,12 +664,14 @@ describe("EboProcessor", () => {
             );
 
             const currentEpoch = {
-                currentEpoch: 1n,
-                currentEpochBlockNumber: 1n,
-                currentEpochTimestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)),
+                number: 1n,
+                firstBlockNumber: 1n,
+                startTimestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as Timestamp,
             };
 
-            const currentBlock = currentEpoch.currentEpochBlockNumber + 10n;
+            const currentBlock = {
+                number: currentEpoch.number + 10n,
+            } as unknown as Block<bigint, false, "finalized">;
 
             vi.spyOn(protocolProvider, "getAccountingApprovedModules").mockResolvedValue(
                 allModulesApproved,

--- a/packages/blocknumber/src/exceptions/invalidTimestamp.ts
+++ b/packages/blocknumber/src/exceptions/invalidTimestamp.ts
@@ -1,7 +1,7 @@
-import { Timestamp } from "@ebo-agent/shared";
+import { UnixTimestamp } from "@ebo-agent/shared";
 
 export class InvalidTimestamp extends Error {
-    constructor(timestamp: number | Timestamp) {
+    constructor(timestamp: number | UnixTimestamp) {
         super(`Timestamp ${timestamp} is prior the timestamp of the first block.`);
 
         this.name = "InvalidTimestamp";

--- a/packages/blocknumber/src/exceptions/invalidTimestamp.ts
+++ b/packages/blocknumber/src/exceptions/invalidTimestamp.ts
@@ -1,5 +1,7 @@
+import { Timestamp } from "@ebo-agent/shared";
+
 export class InvalidTimestamp extends Error {
-    constructor(timestamp: number | bigint) {
+    constructor(timestamp: number | Timestamp) {
         super(`Timestamp ${timestamp} is prior the timestamp of the first block.`);
 
         this.name = "InvalidTimestamp";

--- a/packages/blocknumber/src/exceptions/unsupportedBlockNumber.ts
+++ b/packages/blocknumber/src/exceptions/unsupportedBlockNumber.ts
@@ -1,7 +1,7 @@
-import { Timestamp } from "@ebo-agent/shared";
+import { UnixTimestamp } from "@ebo-agent/shared";
 
 export class UnsupportedBlockNumber extends Error {
-    constructor(timestamp: Timestamp) {
+    constructor(timestamp: UnixTimestamp) {
         super(`Block with null block number at ${timestamp}`);
 
         this.name = "UnsupportedBlockNumber";

--- a/packages/blocknumber/src/providers/blockNumberProvider.ts
+++ b/packages/blocknumber/src/providers/blockNumberProvider.ts
@@ -1,4 +1,4 @@
-import { Timestamp } from "@ebo-agent/shared";
+import { UnixTimestamp } from "@ebo-agent/shared";
 
 export interface BlockNumberProvider {
     /**
@@ -11,5 +11,5 @@ export interface BlockNumberProvider {
      *
      * @returns the corresponding block number of a chain at a specific timestamp
      */
-    getEpochBlockNumber(timestamp: Timestamp): Promise<bigint>;
+    getEpochBlockNumber(timestamp: UnixTimestamp): Promise<bigint>;
 }

--- a/packages/blocknumber/src/providers/blockmetaJsonBlockNumberProvider.ts
+++ b/packages/blocknumber/src/providers/blockmetaJsonBlockNumberProvider.ts
@@ -1,4 +1,4 @@
-import { ILogger, Timestamp } from "@ebo-agent/shared";
+import { ILogger, UnixTimestamp } from "@ebo-agent/shared";
 import axios, {
     AxiosInstance,
     AxiosResponse,
@@ -126,7 +126,7 @@ export class BlockmetaJsonBlockNumberProvider implements BlockNumberProvider {
     }
 
     /** @inheritdoc */
-    async getEpochBlockNumber(timestamp: Timestamp): Promise<bigint> {
+    async getEpochBlockNumber(timestamp: UnixTimestamp): Promise<bigint> {
         if (timestamp > Number.MAX_SAFE_INTEGER || timestamp < 0)
             throw new RangeError(`Timestamp ${timestamp.toString()} cannot be casted to a Number.`);
 

--- a/packages/blocknumber/src/providers/evmBlockNumberProvider.ts
+++ b/packages/blocknumber/src/providers/evmBlockNumberProvider.ts
@@ -106,7 +106,7 @@ export class EvmBlockNumberProvider implements BlockNumberProvider {
      * @returns true if the block contains a non-null number
      */
     private validateBlockNumber(block: Block): block is BlockWithNumber {
-        if (block.number === null) throw new UnsupportedBlockNumber(block.timestamp);
+        if (block.number === null) throw new UnsupportedBlockNumber(block.timestamp as Timestamp);
 
         return true;
     }

--- a/packages/blocknumber/src/providers/evmBlockNumberProvider.ts
+++ b/packages/blocknumber/src/providers/evmBlockNumberProvider.ts
@@ -1,4 +1,4 @@
-import { ILogger, Timestamp } from "@ebo-agent/shared";
+import { ILogger, UnixTimestamp } from "@ebo-agent/shared";
 import { Block, FallbackTransport, HttpTransport, PublicClient } from "viem";
 
 import {
@@ -56,7 +56,7 @@ export class EvmBlockNumberProvider implements BlockNumberProvider {
         this.firstBlock = null;
     }
 
-    async getEpochBlockNumber(timestamp: Timestamp): Promise<bigint> {
+    async getEpochBlockNumber(timestamp: UnixTimestamp): Promise<bigint> {
         // An optimized binary search is used to look for the epoch block.
 
         // The EBO agent looks only for finalized blocks to avoid handling reorgs
@@ -106,7 +106,8 @@ export class EvmBlockNumberProvider implements BlockNumberProvider {
      * @returns true if the block contains a non-null number
      */
     private validateBlockNumber(block: Block): block is BlockWithNumber {
-        if (block.number === null) throw new UnsupportedBlockNumber(block.timestamp as Timestamp);
+        if (block.number === null)
+            throw new UnsupportedBlockNumber(block.timestamp as UnixTimestamp);
 
         return true;
     }
@@ -125,7 +126,7 @@ export class EvmBlockNumberProvider implements BlockNumberProvider {
      * @param lastBlock last block of the chain
      * @returns an optimized lower bound for a binary search space
      */
-    private async calculateLowerBoundBlock(timestamp: Timestamp, lastBlock: BlockWithNumber) {
+    private async calculateLowerBoundBlock(timestamp: UnixTimestamp, lastBlock: BlockWithNumber) {
         const { blocksLookback, deltaMultiplier } = this.searchConfig;
 
         const estimatedBlockTime = await this.estimateBlockTime(lastBlock, blocksLookback);
@@ -191,7 +192,7 @@ export class EvmBlockNumberProvider implements BlockNumberProvider {
      * @returns the block number
      */
     private async searchTimestamp(
-        timestamp: Timestamp,
+        timestamp: UnixTimestamp,
         between: { fromBlock: bigint; toBlock: bigint },
     ) {
         let currentBlockNumber: bigint;

--- a/packages/blocknumber/src/services/blockNumberService.ts
+++ b/packages/blocknumber/src/services/blockNumberService.ts
@@ -1,4 +1,4 @@
-import { EBO_SUPPORTED_CHAIN_IDS, ILogger, Timestamp } from "@ebo-agent/shared";
+import { EBO_SUPPORTED_CHAIN_IDS, ILogger, UnixTimestamp } from "@ebo-agent/shared";
 import { createPublicClient, fallback, http } from "viem";
 
 import { ChainWithoutProvider, EmptyRpcUrls, UnsupportedChain } from "../exceptions/index.js";
@@ -34,7 +34,10 @@ export class BlockNumberService {
      * @param chainId the CAIP-2 chain id
      * @returns the block number corresponding to the timestamp
      */
-    public async getEpochBlockNumber(timestamp: Timestamp, chainId: Caip2ChainId): Promise<bigint> {
+    public async getEpochBlockNumber(
+        timestamp: UnixTimestamp,
+        chainId: Caip2ChainId,
+    ): Promise<bigint> {
         const provider = this.blockNumberProviders.get(chainId);
 
         if (!provider) throw new ChainWithoutProvider(chainId);
@@ -51,7 +54,7 @@ export class BlockNumberService {
      * @param chains a list of CAIP-2 chain ids
      * @returns a map of CAIP-2 chain ids
      */
-    public async getEpochBlockNumbers(timestamp: Timestamp, chains: Caip2ChainId[]) {
+    public async getEpochBlockNumbers(timestamp: UnixTimestamp, chains: Caip2ChainId[]) {
         const epochBlockNumbers = await Promise.all(
             chains.map(async (chain) => ({
                 chainId: chain,

--- a/packages/blocknumber/test/providers/evmBlockNumberProvider.spec.ts
+++ b/packages/blocknumber/test/providers/evmBlockNumberProvider.spec.ts
@@ -1,4 +1,4 @@
-import { ILogger } from "@ebo-agent/shared";
+import { ILogger, UnixTimestamp } from "@ebo-agent/shared";
 import { Block, createPublicClient, GetBlockParameters, http } from "viem";
 import { mainnet } from "viem/chains";
 import { describe, expect, it, vi } from "vitest";
@@ -30,7 +30,7 @@ describe("EvmBlockNumberProvider", () => {
 
             evmProvider = new EvmBlockNumberProvider(rpcProvider, searchConfig, logger);
 
-            const day5 = BigInt(Date.UTC(2024, 1, 5, 2, 0, 0, 0));
+            const day5 = BigInt(Date.UTC(2024, 1, 5, 2, 0, 0, 0)) as UnixTimestamp;
             const epochBlockNumber = await evmProvider.getEpochBlockNumber(day5);
 
             expect(epochBlockNumber).toEqual(4n);
@@ -44,7 +44,7 @@ describe("EvmBlockNumberProvider", () => {
 
             evmProvider = new EvmBlockNumberProvider(rpcProvider, searchConfig, logger);
 
-            const exactDay5 = BigInt(Date.UTC(2024, 1, 1, 0, 0, 5, 0));
+            const exactDay5 = BigInt(Date.UTC(2024, 1, 1, 0, 0, 5, 0)) as UnixTimestamp;
             const epochBlockNumber = await evmProvider.getEpochBlockNumber(exactDay5);
 
             expect(epochBlockNumber).toEqual(4n);
@@ -58,7 +58,7 @@ describe("EvmBlockNumberProvider", () => {
 
             evmProvider = new EvmBlockNumberProvider(rpcProvider, searchConfig, logger);
 
-            const futureTimestamp = BigInt(Date.UTC(2025, 1, 1, 0, 0, 0, 0));
+            const futureTimestamp = BigInt(Date.UTC(2025, 1, 1, 0, 0, 0, 0)) as UnixTimestamp;
 
             expect(evmProvider.getEpochBlockNumber(futureTimestamp)).rejects.toBeInstanceOf(
                 LastBlockEpoch,
@@ -73,7 +73,7 @@ describe("EvmBlockNumberProvider", () => {
 
             evmProvider = new EvmBlockNumberProvider(rpcProvider, searchConfig, logger);
 
-            const futureTimestamp = BigInt(Date.UTC(1970, 1, 1, 0, 0, 0, 0));
+            const futureTimestamp = BigInt(Date.UTC(1970, 1, 1, 0, 0, 0, 0)) as UnixTimestamp;
 
             expect(evmProvider.getEpochBlockNumber(futureTimestamp)).rejects.toBeInstanceOf(
                 InvalidTimestamp,
@@ -81,7 +81,7 @@ describe("EvmBlockNumberProvider", () => {
         });
 
         it("fails when finding multiple blocks with the same timestamp", () => {
-            const timestamp = BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0));
+            const timestamp = BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as UnixTimestamp;
             const afterTimestamp = BigInt(Date.UTC(2024, 1, 2, 0, 0, 0, 0));
             const rpcProvider = mockRpcProviderBlocks([
                 { number: 0n, timestamp: timestamp },
@@ -99,7 +99,7 @@ describe("EvmBlockNumberProvider", () => {
         });
 
         it("fails when finding a block with no number", () => {
-            const timestamp = Date.UTC(2024, 1, 1, 0, 0, 0, 0);
+            const timestamp = BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as UnixTimestamp;
             const rpcProvider = mockRpcProviderBlocks([
                 { number: null, timestamp: BigInt(timestamp) },
             ]);
@@ -117,7 +117,7 @@ describe("EvmBlockNumberProvider", () => {
             client.getBlock = vi.fn().mockRejectedValue(null);
 
             evmProvider = new EvmBlockNumberProvider(client, searchConfig, logger);
-            const timestamp = BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0));
+            const timestamp = BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as UnixTimestamp;
 
             expect(evmProvider.getEpochBlockNumber(timestamp)).rejects.toBeDefined();
         });

--- a/packages/shared/src/types/timestamp.ts
+++ b/packages/shared/src/types/timestamp.ts
@@ -1,4 +1,4 @@
 import { Branded } from "./brand.js";
 
 /** Timestamp in seconds since the Unix epoch */
-export type Timestamp = Branded<bigint, "Timestamp">;
+export type UnixTimestamp = Branded<bigint, "UnixTimestamp">;

--- a/packages/shared/src/types/timestamp.ts
+++ b/packages/shared/src/types/timestamp.ts
@@ -1,1 +1,4 @@
-export type Timestamp = bigint;
+import { Branded } from "./brand.js";
+
+/** Timestamp in seconds since the Unix epoch */
+export type Timestamp = Branded<bigint, "Timestamp">;


### PR DESCRIPTION
# 🤖 Linear

Part of GRT-147

## Description

Adapt changes from contracts so timestamps are being used for Prophet logic, instead of using block numbers.