### PR TITLE
test: config & support horizon staking for e2e

### DIFF
--- a/apps/agent/config.example.yml
+++ b/apps/agent/config.example.yml
@@ -1,10 +1,12 @@
 protocolProvider:
     rpcsConfig:
         l1:
+            chainId: eip155:11155111
             transactionReceiptConfirmations: 1
             timeout: 10000
             retryInterval: 150
         l2:
+            chainId: eip155:42161
             transactionReceiptConfirmations: 1
             timeout: 10000
             retryInterval: 150

--- a/apps/agent/src/config/schemas.ts
+++ b/apps/agent/src/config/schemas.ts
@@ -36,6 +36,9 @@ export const envSchema = z.object({
 
 const addressSchema = z.string().refine((address) => isAddress(address));
 const rpcConfigSchema = z.object({
+    chainId: z
+        .string()
+        .refine((id) => Caip2Utils.isCaip2ChainId(id), { message: "Invalid CAIP 2 chain ID" }),
     transactionReceiptConfirmations: z.number().int().positive(),
     timeout: z.number().int().positive(),
     retryInterval: z.number().int().positive(),

--- a/packages/automated-dispute/src/abis/eboRequestCreator.ts
+++ b/packages/automated-dispute/src/abis/eboRequestCreator.ts
@@ -2,27 +2,86 @@ export const eboRequestCreatorAbi = [
     {
         type: "constructor",
         inputs: [
-            { name: "_oracle", type: "address", internalType: "contract IOracle" },
-            { name: "_epochManager", type: "address", internalType: "contract IEpochManager" },
-            { name: "_arbitrator", type: "address", internalType: "address" },
-            { name: "_council", type: "address", internalType: "address" },
+            {
+                name: "_oracle",
+                type: "address",
+                internalType: "contract IOracle",
+            },
+            {
+                name: "_epochManager",
+                type: "address",
+                internalType: "contract IEpochManager",
+            },
+            {
+                name: "_arbitrable",
+                type: "address",
+                internalType: "contract IArbitrable",
+            },
             {
                 name: "_requestData",
                 type: "tuple",
                 internalType: "struct IOracle.Request",
                 components: [
-                    { name: "nonce", type: "uint96", internalType: "uint96" },
-                    { name: "requester", type: "address", internalType: "address" },
-                    { name: "requestModule", type: "address", internalType: "address" },
-                    { name: "responseModule", type: "address", internalType: "address" },
-                    { name: "disputeModule", type: "address", internalType: "address" },
-                    { name: "resolutionModule", type: "address", internalType: "address" },
-                    { name: "finalityModule", type: "address", internalType: "address" },
-                    { name: "requestModuleData", type: "bytes", internalType: "bytes" },
-                    { name: "responseModuleData", type: "bytes", internalType: "bytes" },
-                    { name: "disputeModuleData", type: "bytes", internalType: "bytes" },
-                    { name: "resolutionModuleData", type: "bytes", internalType: "bytes" },
-                    { name: "finalityModuleData", type: "bytes", internalType: "bytes" },
+                    {
+                        name: "nonce",
+                        type: "uint96",
+                        internalType: "uint96",
+                    },
+                    {
+                        name: "requester",
+                        type: "address",
+                        internalType: "address",
+                    },
+                    {
+                        name: "requestModule",
+                        type: "address",
+                        internalType: "address",
+                    },
+                    {
+                        name: "responseModule",
+                        type: "address",
+                        internalType: "address",
+                    },
+                    {
+                        name: "disputeModule",
+                        type: "address",
+                        internalType: "address",
+                    },
+                    {
+                        name: "resolutionModule",
+                        type: "address",
+                        internalType: "address",
+                    },
+                    {
+                        name: "finalityModule",
+                        type: "address",
+                        internalType: "address",
+                    },
+                    {
+                        name: "requestModuleData",
+                        type: "bytes",
+                        internalType: "bytes",
+                    },
+                    {
+                        name: "responseModuleData",
+                        type: "bytes",
+                        internalType: "bytes",
+                    },
+                    {
+                        name: "disputeModuleData",
+                        type: "bytes",
+                        internalType: "bytes",
+                    },
+                    {
+                        name: "resolutionModuleData",
+                        type: "bytes",
+                        internalType: "bytes",
+                    },
+                    {
+                        name: "finalityModuleData",
+                        type: "bytes",
+                        internalType: "bytes",
+                    },
                 ],
             },
         ],
@@ -30,52 +89,70 @@ export const eboRequestCreatorAbi = [
     },
     {
         type: "function",
+        name: "ARBITRABLE",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "contract IArbitrable",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
         name: "ORACLE",
         inputs: [],
-        outputs: [{ name: "", type: "address", internalType: "contract IOracle" }],
+        outputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "contract IOracle",
+            },
+        ],
         stateMutability: "view",
     },
     {
         type: "function",
         name: "START_EPOCH",
         inputs: [],
-        outputs: [{ name: "", type: "uint256", internalType: "uint256" }],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
         stateMutability: "view",
     },
     {
         type: "function",
         name: "addChain",
-        inputs: [{ name: "_chainId", type: "string", internalType: "string" }],
+        inputs: [
+            {
+                name: "_chainId",
+                type: "string",
+                internalType: "string",
+            },
+        ],
         outputs: [],
         stateMutability: "nonpayable",
-    },
-    {
-        type: "function",
-        name: "arbitrator",
-        inputs: [],
-        outputs: [{ name: "__arbitrator", type: "address", internalType: "address" }],
-        stateMutability: "view",
-    },
-    {
-        type: "function",
-        name: "confirmCouncil",
-        inputs: [],
-        outputs: [],
-        stateMutability: "nonpayable",
-    },
-    {
-        type: "function",
-        name: "council",
-        inputs: [],
-        outputs: [{ name: "__council", type: "address", internalType: "address" }],
-        stateMutability: "view",
     },
     {
         type: "function",
         name: "createRequest",
         inputs: [
-            { name: "_epoch", type: "uint256", internalType: "uint256" },
-            { name: "_chainId", type: "string", internalType: "string" },
+            {
+                name: "_epoch",
+                type: "uint256",
+                internalType: "uint256",
+            },
+            {
+                name: "_chainId",
+                type: "string",
+                internalType: "string",
+            },
         ],
         outputs: [],
         stateMutability: "nonpayable",
@@ -84,20 +161,113 @@ export const eboRequestCreatorAbi = [
         type: "function",
         name: "epochManager",
         inputs: [],
-        outputs: [{ name: "", type: "address", internalType: "contract IEpochManager" }],
+        outputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "contract IEpochManager",
+            },
+        ],
         stateMutability: "view",
     },
     {
         type: "function",
-        name: "pendingCouncil",
+        name: "getAllowedChainIds",
         inputs: [],
-        outputs: [{ name: "__pendingCouncil", type: "address", internalType: "address" }],
+        outputs: [
+            {
+                name: "_chainIds",
+                type: "bytes32[]",
+                internalType: "bytes32[]",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "getRequestData",
+        inputs: [],
+        outputs: [
+            {
+                name: "_requestData",
+                type: "tuple",
+                internalType: "struct IOracle.Request",
+                components: [
+                    {
+                        name: "nonce",
+                        type: "uint96",
+                        internalType: "uint96",
+                    },
+                    {
+                        name: "requester",
+                        type: "address",
+                        internalType: "address",
+                    },
+                    {
+                        name: "requestModule",
+                        type: "address",
+                        internalType: "address",
+                    },
+                    {
+                        name: "responseModule",
+                        type: "address",
+                        internalType: "address",
+                    },
+                    {
+                        name: "disputeModule",
+                        type: "address",
+                        internalType: "address",
+                    },
+                    {
+                        name: "resolutionModule",
+                        type: "address",
+                        internalType: "address",
+                    },
+                    {
+                        name: "finalityModule",
+                        type: "address",
+                        internalType: "address",
+                    },
+                    {
+                        name: "requestModuleData",
+                        type: "bytes",
+                        internalType: "bytes",
+                    },
+                    {
+                        name: "responseModuleData",
+                        type: "bytes",
+                        internalType: "bytes",
+                    },
+                    {
+                        name: "disputeModuleData",
+                        type: "bytes",
+                        internalType: "bytes",
+                    },
+                    {
+                        name: "resolutionModuleData",
+                        type: "bytes",
+                        internalType: "bytes",
+                    },
+                    {
+                        name: "finalityModuleData",
+                        type: "bytes",
+                        internalType: "bytes",
+                    },
+                ],
+            },
+        ],
         stateMutability: "view",
     },
     {
         type: "function",
         name: "removeChain",
-        inputs: [{ name: "_chainId", type: "string", internalType: "string" }],
+        inputs: [
+            {
+                name: "_chainId",
+                type: "string",
+                internalType: "string",
+            },
+        ],
         outputs: [],
         stateMutability: "nonpayable",
     },
@@ -106,18 +276,66 @@ export const eboRequestCreatorAbi = [
         name: "requestData",
         inputs: [],
         outputs: [
-            { name: "nonce", type: "uint96", internalType: "uint96" },
-            { name: "requester", type: "address", internalType: "address" },
-            { name: "requestModule", type: "address", internalType: "address" },
-            { name: "responseModule", type: "address", internalType: "address" },
-            { name: "disputeModule", type: "address", internalType: "address" },
-            { name: "resolutionModule", type: "address", internalType: "address" },
-            { name: "finalityModule", type: "address", internalType: "address" },
-            { name: "requestModuleData", type: "bytes", internalType: "bytes" },
-            { name: "responseModuleData", type: "bytes", internalType: "bytes" },
-            { name: "disputeModuleData", type: "bytes", internalType: "bytes" },
-            { name: "resolutionModuleData", type: "bytes", internalType: "bytes" },
-            { name: "finalityModuleData", type: "bytes", internalType: "bytes" },
+            {
+                name: "nonce",
+                type: "uint96",
+                internalType: "uint96",
+            },
+            {
+                name: "requester",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "requestModule",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "responseModule",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "disputeModule",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "resolutionModule",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "finalityModule",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "requestModuleData",
+                type: "bytes",
+                internalType: "bytes",
+            },
+            {
+                name: "responseModuleData",
+                type: "bytes",
+                internalType: "bytes",
+            },
+            {
+                name: "disputeModuleData",
+                type: "bytes",
+                internalType: "bytes",
+            },
+            {
+                name: "resolutionModuleData",
+                type: "bytes",
+                internalType: "bytes",
+            },
+            {
+                name: "finalityModuleData",
+                type: "bytes",
+                internalType: "bytes",
+            },
         ],
         stateMutability: "view",
     },
@@ -125,24 +343,35 @@ export const eboRequestCreatorAbi = [
         type: "function",
         name: "requestIdPerChainAndEpoch",
         inputs: [
-            { name: "_chainId", type: "string", internalType: "string" },
-            { name: "_epoch", type: "uint256", internalType: "uint256" },
+            {
+                name: "_chainId",
+                type: "string",
+                internalType: "string",
+            },
+            {
+                name: "_epoch",
+                type: "uint256",
+                internalType: "uint256",
+            },
         ],
-        outputs: [{ name: "_requestId", type: "bytes32", internalType: "bytes32" }],
+        outputs: [
+            {
+                name: "_requestId",
+                type: "bytes32",
+                internalType: "bytes32",
+            },
+        ],
         stateMutability: "view",
-    },
-    {
-        type: "function",
-        name: "setArbitrator",
-        inputs: [{ name: "__arbitrator", type: "address", internalType: "address" }],
-        outputs: [],
-        stateMutability: "nonpayable",
     },
     {
         type: "function",
         name: "setDisputeModuleData",
         inputs: [
-            { name: "_disputeModule", type: "address", internalType: "address" },
+            {
+                name: "_disputeModule",
+                type: "address",
+                internalType: "address",
+            },
             {
                 name: "_disputeModuleData",
                 type: "tuple",
@@ -153,12 +382,36 @@ export const eboRequestCreatorAbi = [
                         type: "address",
                         internalType: "contract IBondEscalationAccounting",
                     },
-                    { name: "bondToken", type: "address", internalType: "contract IERC20" },
-                    { name: "bondSize", type: "uint256", internalType: "uint256" },
-                    { name: "maxNumberOfEscalations", type: "uint256", internalType: "uint256" },
-                    { name: "bondEscalationDeadline", type: "uint256", internalType: "uint256" },
-                    { name: "tyingBuffer", type: "uint256", internalType: "uint256" },
-                    { name: "disputeWindow", type: "uint256", internalType: "uint256" },
+                    {
+                        name: "bondToken",
+                        type: "address",
+                        internalType: "contract IERC20",
+                    },
+                    {
+                        name: "bondSize",
+                        type: "uint256",
+                        internalType: "uint256",
+                    },
+                    {
+                        name: "maxNumberOfEscalations",
+                        type: "uint256",
+                        internalType: "uint256",
+                    },
+                    {
+                        name: "bondEscalationDeadline",
+                        type: "uint256",
+                        internalType: "uint256",
+                    },
+                    {
+                        name: "tyingBuffer",
+                        type: "uint256",
+                        internalType: "uint256",
+                    },
+                    {
+                        name: "disputeWindow",
+                        type: "uint256",
+                        internalType: "uint256",
+                    },
                 ],
             },
         ],
@@ -169,7 +422,11 @@ export const eboRequestCreatorAbi = [
         type: "function",
         name: "setEpochManager",
         inputs: [
-            { name: "_epochManager", type: "address", internalType: "contract IEpochManager" },
+            {
+                name: "_epochManager",
+                type: "address",
+                internalType: "contract IEpochManager",
+            },
         ],
         outputs: [],
         stateMutability: "nonpayable",
@@ -178,16 +435,12 @@ export const eboRequestCreatorAbi = [
         type: "function",
         name: "setFinalityModuleData",
         inputs: [
-            { name: "_finalityModule", type: "address", internalType: "address" },
-            { name: "_finalityModuleData", type: "bytes", internalType: "bytes" },
+            {
+                name: "_finalityModule",
+                type: "address",
+                internalType: "address",
+            },
         ],
-        outputs: [],
-        stateMutability: "nonpayable",
-    },
-    {
-        type: "function",
-        name: "setPendingCouncil",
-        inputs: [{ name: "__pendingCouncil", type: "address", internalType: "address" }],
         outputs: [],
         stateMutability: "nonpayable",
     },
@@ -195,20 +448,36 @@ export const eboRequestCreatorAbi = [
         type: "function",
         name: "setRequestModuleData",
         inputs: [
-            { name: "_requestModule", type: "address", internalType: "address" },
+            {
+                name: "_requestModule",
+                type: "address",
+                internalType: "address",
+            },
             {
                 name: "_requestModuleData",
                 type: "tuple",
                 internalType: "struct IEBORequestModule.RequestParameters",
                 components: [
-                    { name: "epoch", type: "uint256", internalType: "uint256" },
-                    { name: "chainId", type: "string", internalType: "string" },
+                    {
+                        name: "epoch",
+                        type: "uint256",
+                        internalType: "uint256",
+                    },
+                    {
+                        name: "chainId",
+                        type: "string",
+                        internalType: "string",
+                    },
                     {
                         name: "accountingExtension",
                         type: "address",
                         internalType: "contract IAccountingExtension",
                     },
-                    { name: "paymentAmount", type: "uint256", internalType: "uint256" },
+                    {
+                        name: "paymentAmount",
+                        type: "uint256",
+                        internalType: "uint256",
+                    },
                 ],
             },
         ],
@@ -219,8 +488,23 @@ export const eboRequestCreatorAbi = [
         type: "function",
         name: "setResolutionModuleData",
         inputs: [
-            { name: "_resolutionModule", type: "address", internalType: "address" },
-            { name: "_resolutionModuleData", type: "bytes", internalType: "bytes" },
+            {
+                name: "_resolutionModule",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "_resolutionModuleData",
+                type: "tuple",
+                internalType: "struct IArbitratorModule.RequestParameters",
+                components: [
+                    {
+                        name: "arbitrator",
+                        type: "address",
+                        internalType: "address",
+                    },
+                ],
+            },
         ],
         outputs: [],
         stateMutability: "nonpayable",
@@ -229,7 +513,11 @@ export const eboRequestCreatorAbi = [
         type: "function",
         name: "setResponseModuleData",
         inputs: [
-            { name: "_responseModule", type: "address", internalType: "address" },
+            {
+                name: "_responseModule",
+                type: "address",
+                internalType: "address",
+            },
             {
                 name: "_responseModuleData",
                 type: "tuple",
@@ -240,10 +528,26 @@ export const eboRequestCreatorAbi = [
                         type: "address",
                         internalType: "contract IAccountingExtension",
                     },
-                    { name: "bondToken", type: "address", internalType: "contract IERC20" },
-                    { name: "bondSize", type: "uint256", internalType: "uint256" },
-                    { name: "deadline", type: "uint256", internalType: "uint256" },
-                    { name: "disputeWindow", type: "uint256", internalType: "uint256" },
+                    {
+                        name: "bondToken",
+                        type: "address",
+                        internalType: "contract IERC20",
+                    },
+                    {
+                        name: "bondSize",
+                        type: "uint256",
+                        internalType: "uint256",
+                    },
+                    {
+                        name: "deadline",
+                        type: "uint256",
+                        internalType: "uint256",
+                    },
+                    {
+                        name: "disputeWindow",
+                        type: "uint256",
+                        internalType: "uint256",
+                    },
                 ],
             },
         ],
@@ -253,20 +557,39 @@ export const eboRequestCreatorAbi = [
     {
         type: "event",
         name: "ChainAdded",
-        inputs: [{ name: "_chainId", type: "string", indexed: true, internalType: "string" }],
+        inputs: [
+            {
+                name: "_chainId",
+                type: "string",
+                indexed: true,
+                internalType: "string",
+            },
+        ],
         anonymous: false,
     },
     {
         type: "event",
         name: "ChainRemoved",
-        inputs: [{ name: "_chainId", type: "string", indexed: true, internalType: "string" }],
+        inputs: [
+            {
+                name: "_chainId",
+                type: "string",
+                indexed: true,
+                internalType: "string",
+            },
+        ],
         anonymous: false,
     },
     {
         type: "event",
         name: "DisputeModuleDataSet",
         inputs: [
-            { name: "_disputeModule", type: "address", indexed: true, internalType: "address" },
+            {
+                name: "_disputeModule",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
             {
                 name: "_disputeModuleData",
                 type: "tuple",
@@ -278,12 +601,36 @@ export const eboRequestCreatorAbi = [
                         type: "address",
                         internalType: "contract IBondEscalationAccounting",
                     },
-                    { name: "bondToken", type: "address", internalType: "contract IERC20" },
-                    { name: "bondSize", type: "uint256", internalType: "uint256" },
-                    { name: "maxNumberOfEscalations", type: "uint256", internalType: "uint256" },
-                    { name: "bondEscalationDeadline", type: "uint256", internalType: "uint256" },
-                    { name: "tyingBuffer", type: "uint256", internalType: "uint256" },
-                    { name: "disputeWindow", type: "uint256", internalType: "uint256" },
+                    {
+                        name: "bondToken",
+                        type: "address",
+                        internalType: "contract IERC20",
+                    },
+                    {
+                        name: "bondSize",
+                        type: "uint256",
+                        internalType: "uint256",
+                    },
+                    {
+                        name: "maxNumberOfEscalations",
+                        type: "uint256",
+                        internalType: "uint256",
+                    },
+                    {
+                        name: "bondEscalationDeadline",
+                        type: "uint256",
+                        internalType: "uint256",
+                    },
+                    {
+                        name: "tyingBuffer",
+                        type: "uint256",
+                        internalType: "uint256",
+                    },
+                    {
+                        name: "disputeWindow",
+                        type: "uint256",
+                        internalType: "uint256",
+                    },
                 ],
             },
         ],
@@ -306,8 +653,18 @@ export const eboRequestCreatorAbi = [
         type: "event",
         name: "FinalityModuleDataSet",
         inputs: [
-            { name: "_finalityModule", type: "address", indexed: true, internalType: "address" },
-            { name: "_finalityModuleData", type: "bytes", indexed: false, internalType: "bytes" },
+            {
+                name: "_finalityModule",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "_finalityModuleData",
+                type: "bytes",
+                indexed: false,
+                internalType: "bytes",
+            },
         ],
         anonymous: false,
     },
@@ -315,9 +672,92 @@ export const eboRequestCreatorAbi = [
         type: "event",
         name: "RequestCreated",
         inputs: [
-            { name: "_requestId", type: "bytes32", indexed: true, internalType: "bytes32" },
-            { name: "_epoch", type: "uint256", indexed: true, internalType: "uint256" },
-            { name: "_chainId", type: "string", indexed: true, internalType: "string" },
+            {
+                name: "_requestId",
+                type: "bytes32",
+                indexed: true,
+                internalType: "bytes32",
+            },
+            {
+                name: "_request",
+                type: "tuple",
+                indexed: false,
+                internalType: "struct IOracle.Request",
+                components: [
+                    {
+                        name: "nonce",
+                        type: "uint96",
+                        internalType: "uint96",
+                    },
+                    {
+                        name: "requester",
+                        type: "address",
+                        internalType: "address",
+                    },
+                    {
+                        name: "requestModule",
+                        type: "address",
+                        internalType: "address",
+                    },
+                    {
+                        name: "responseModule",
+                        type: "address",
+                        internalType: "address",
+                    },
+                    {
+                        name: "disputeModule",
+                        type: "address",
+                        internalType: "address",
+                    },
+                    {
+                        name: "resolutionModule",
+                        type: "address",
+                        internalType: "address",
+                    },
+                    {
+                        name: "finalityModule",
+                        type: "address",
+                        internalType: "address",
+                    },
+                    {
+                        name: "requestModuleData",
+                        type: "bytes",
+                        internalType: "bytes",
+                    },
+                    {
+                        name: "responseModuleData",
+                        type: "bytes",
+                        internalType: "bytes",
+                    },
+                    {
+                        name: "disputeModuleData",
+                        type: "bytes",
+                        internalType: "bytes",
+                    },
+                    {
+                        name: "resolutionModuleData",
+                        type: "bytes",
+                        internalType: "bytes",
+                    },
+                    {
+                        name: "finalityModuleData",
+                        type: "bytes",
+                        internalType: "bytes",
+                    },
+                ],
+            },
+            {
+                name: "_epoch",
+                type: "uint256",
+                indexed: true,
+                internalType: "uint256",
+            },
+            {
+                name: "_chainId",
+                type: "string",
+                indexed: true,
+                internalType: "string",
+            },
         ],
         anonymous: false,
     },
@@ -325,21 +765,38 @@ export const eboRequestCreatorAbi = [
         type: "event",
         name: "RequestModuleDataSet",
         inputs: [
-            { name: "_requestModule", type: "address", indexed: true, internalType: "address" },
+            {
+                name: "_requestModule",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
             {
                 name: "_requestModuleData",
                 type: "tuple",
                 indexed: false,
                 internalType: "struct IEBORequestModule.RequestParameters",
                 components: [
-                    { name: "epoch", type: "uint256", internalType: "uint256" },
-                    { name: "chainId", type: "string", internalType: "string" },
+                    {
+                        name: "epoch",
+                        type: "uint256",
+                        internalType: "uint256",
+                    },
+                    {
+                        name: "chainId",
+                        type: "string",
+                        internalType: "string",
+                    },
                     {
                         name: "accountingExtension",
                         type: "address",
                         internalType: "contract IAccountingExtension",
                     },
-                    { name: "paymentAmount", type: "uint256", internalType: "uint256" },
+                    {
+                        name: "paymentAmount",
+                        type: "uint256",
+                        internalType: "uint256",
+                    },
                 ],
             },
         ],
@@ -349,8 +806,25 @@ export const eboRequestCreatorAbi = [
         type: "event",
         name: "ResolutionModuleDataSet",
         inputs: [
-            { name: "_resolutionModule", type: "address", indexed: true, internalType: "address" },
-            { name: "_resolutionModuleData", type: "bytes", indexed: false, internalType: "bytes" },
+            {
+                name: "_resolutionModule",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "_resolutionModuleData",
+                type: "tuple",
+                indexed: false,
+                internalType: "struct IArbitratorModule.RequestParameters",
+                components: [
+                    {
+                        name: "arbitrator",
+                        type: "address",
+                        internalType: "address",
+                    },
+                ],
+            },
         ],
         anonymous: false,
     },
@@ -358,7 +832,12 @@ export const eboRequestCreatorAbi = [
         type: "event",
         name: "ResponseModuleDataSet",
         inputs: [
-            { name: "_responseModule", type: "address", indexed: true, internalType: "address" },
+            {
+                name: "_responseModule",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
             {
                 name: "_responseModuleData",
                 type: "tuple",
@@ -370,40 +849,54 @@ export const eboRequestCreatorAbi = [
                         type: "address",
                         internalType: "contract IAccountingExtension",
                     },
-                    { name: "bondToken", type: "address", internalType: "contract IERC20" },
-                    { name: "bondSize", type: "uint256", internalType: "uint256" },
-                    { name: "deadline", type: "uint256", internalType: "uint256" },
-                    { name: "disputeWindow", type: "uint256", internalType: "uint256" },
+                    {
+                        name: "bondToken",
+                        type: "address",
+                        internalType: "contract IERC20",
+                    },
+                    {
+                        name: "bondSize",
+                        type: "uint256",
+                        internalType: "uint256",
+                    },
+                    {
+                        name: "deadline",
+                        type: "uint256",
+                        internalType: "uint256",
+                    },
+                    {
+                        name: "disputeWindow",
+                        type: "uint256",
+                        internalType: "uint256",
+                    },
                 ],
             },
         ],
         anonymous: false,
     },
     {
-        type: "event",
-        name: "SetArbitrator",
-        inputs: [{ name: "_arbitrator", type: "address", indexed: true, internalType: "address" }],
-        anonymous: false,
+        type: "error",
+        name: "EBORequestCreator_ChainAlreadyAdded",
+        inputs: [],
     },
     {
-        type: "event",
-        name: "SetCouncil",
-        inputs: [{ name: "_council", type: "address", indexed: true, internalType: "address" }],
-        anonymous: false,
+        type: "error",
+        name: "EBORequestCreator_ChainNotAdded",
+        inputs: [],
     },
     {
-        type: "event",
-        name: "SetPendingCouncil",
-        inputs: [
-            { name: "_pendingCouncil", type: "address", indexed: true, internalType: "address" },
-        ],
-        anonymous: false,
+        type: "error",
+        name: "EBORequestCreator_InvalidEpoch",
+        inputs: [],
     },
-    { type: "error", name: "Arbitrable_OnlyArbitrator", inputs: [] },
-    { type: "error", name: "Arbitrable_OnlyCouncil", inputs: [] },
-    { type: "error", name: "Arbitrable_OnlyPendingCouncil", inputs: [] },
-    { type: "error", name: "EBORequestCreator_ChainAlreadyAdded", inputs: [] },
-    { type: "error", name: "EBORequestCreator_ChainNotAdded", inputs: [] },
-    { type: "error", name: "EBORequestCreator_InvalidEpoch", inputs: [] },
-    { type: "error", name: "EBORequestCreator_InvalidNonce", inputs: [] },
+    {
+        type: "error",
+        name: "EBORequestCreator_InvalidNonce",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "EBORequestCreator_RequestAlreadyCreated",
+        inputs: [],
+    },
 ] as const;

--- a/packages/automated-dispute/src/abis/horizonAccountingExtension.ts
+++ b/packages/automated-dispute/src/abis/horizonAccountingExtension.ts
@@ -2,84 +2,215 @@ export const horizonAccountingExtensionAbi = [
     {
         type: "constructor",
         inputs: [
-            { name: "_horizonStaking", type: "address", internalType: "contract IHorizonStaking" },
-            { name: "_oracle", type: "address", internalType: "contract IOracle" },
-            { name: "_grt", type: "address", internalType: "contract IERC20" },
-            { name: "_minThawingPeriod", type: "uint256", internalType: "uint256" },
+            {
+                name: "_horizonStaking",
+                type: "address",
+                internalType: "contract IHorizonStaking",
+            },
+            {
+                name: "_oracle",
+                type: "address",
+                internalType: "contract IOracle",
+            },
+            {
+                name: "_grt",
+                type: "address",
+                internalType: "contract IERC20",
+            },
+            {
+                name: "_arbitrable",
+                type: "address",
+                internalType: "contract IArbitrable",
+            },
+            {
+                name: "_minThawingPeriod",
+                type: "uint64",
+                internalType: "uint64",
+            },
+            {
+                name: "_maxUsersToCheck",
+                type: "uint128",
+                internalType: "uint128",
+            },
+            {
+                name: "_authorizedCallers",
+                type: "address[]",
+                internalType: "address[]",
+            },
         ],
         stateMutability: "nonpayable",
     },
     {
         type: "function",
+        name: "ARBITRABLE",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "contract IArbitrable",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
         name: "GRT",
         inputs: [],
-        outputs: [{ name: "", type: "address", internalType: "contract IERC20" }],
+        outputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "contract IERC20",
+            },
+        ],
         stateMutability: "view",
     },
     {
         type: "function",
         name: "HORIZON_STAKING",
         inputs: [],
-        outputs: [{ name: "", type: "address", internalType: "contract IHorizonStaking" }],
+        outputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "contract IHorizonStaking",
+            },
+        ],
         stateMutability: "view",
     },
     {
         type: "function",
-        name: "MAX_SLASHING_USERS",
+        name: "MAX_USERS_TO_SLASH",
         inputs: [],
-        outputs: [{ name: "", type: "uint256", internalType: "uint256" }],
-        stateMutability: "view",
-    },
-    {
-        type: "function",
-        name: "MAX_USERS_TO_CHECK",
-        inputs: [],
-        outputs: [{ name: "", type: "uint256", internalType: "uint256" }],
+        outputs: [
+            {
+                name: "",
+                type: "uint32",
+                internalType: "uint32",
+            },
+        ],
         stateMutability: "view",
     },
     {
         type: "function",
         name: "MAX_VERIFIER_CUT",
         inputs: [],
-        outputs: [{ name: "", type: "uint256", internalType: "uint256" }],
+        outputs: [
+            {
+                name: "",
+                type: "uint32",
+                internalType: "uint32",
+            },
+        ],
         stateMutability: "view",
     },
     {
         type: "function",
         name: "MIN_THAWING_PERIOD",
         inputs: [],
-        outputs: [{ name: "", type: "uint256", internalType: "uint256" }],
+        outputs: [
+            {
+                name: "",
+                type: "uint64",
+                internalType: "uint64",
+            },
+        ],
         stateMutability: "view",
     },
     {
         type: "function",
         name: "ORACLE",
         inputs: [],
-        outputs: [{ name: "", type: "address", internalType: "contract IOracle" }],
+        outputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "contract IOracle",
+            },
+        ],
         stateMutability: "view",
     },
     {
         type: "function",
         name: "approveModule",
-        inputs: [{ name: "_module", type: "address", internalType: "address" }],
+        inputs: [
+            {
+                name: "_module",
+                type: "address",
+                internalType: "address",
+            },
+        ],
         outputs: [],
         stateMutability: "nonpayable",
     },
     {
         type: "function",
         name: "approvedModules",
-        inputs: [{ name: "_user", type: "address", internalType: "address" }],
-        outputs: [{ name: "_approvedModules", type: "address[]", internalType: "address[]" }],
+        inputs: [
+            {
+                name: "_user",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "_approvedModules",
+                type: "address[]",
+                internalType: "address[]",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "authorizedCallers",
+        inputs: [
+            {
+                name: "_caller",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "_authorized",
+                type: "bool",
+                internalType: "bool",
+            },
+        ],
         stateMutability: "view",
     },
     {
         type: "function",
         name: "bond",
         inputs: [
-            { name: "_bonder", type: "address", internalType: "address" },
-            { name: "_requestId", type: "bytes32", internalType: "bytes32" },
-            { name: "_amount", type: "uint256", internalType: "uint256" },
-            { name: "_sender", type: "address", internalType: "address" },
+            {
+                name: "_bonder",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "_requestId",
+                type: "bytes32",
+                internalType: "bytes32",
+            },
+            {
+                name: "",
+                type: "address",
+                internalType: "contract IERC20",
+            },
+            {
+                name: "_amount",
+                type: "uint256",
+                internalType: "uint256",
+            },
+            {
+                name: "_sender",
+                type: "address",
+                internalType: "address",
+            },
         ],
         outputs: [],
         stateMutability: "nonpayable",
@@ -88,9 +219,26 @@ export const horizonAccountingExtensionAbi = [
         type: "function",
         name: "bond",
         inputs: [
-            { name: "_bonder", type: "address", internalType: "address" },
-            { name: "_requestId", type: "bytes32", internalType: "bytes32" },
-            { name: "_amount", type: "uint256", internalType: "uint256" },
+            {
+                name: "_bonder",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "_requestId",
+                type: "bytes32",
+                internalType: "bytes32",
+            },
+            {
+                name: "",
+                type: "address",
+                internalType: "contract IERC20",
+            },
+            {
+                name: "_amount",
+                type: "uint256",
+                internalType: "uint256",
+            },
         ],
         outputs: [],
         stateMutability: "nonpayable",
@@ -99,34 +247,147 @@ export const horizonAccountingExtensionAbi = [
         type: "function",
         name: "bondedForRequest",
         inputs: [
-            { name: "_bonder", type: "address", internalType: "address" },
-            { name: "_requestId", type: "bytes32", internalType: "bytes32" },
+            {
+                name: "_bonder",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "_requestId",
+                type: "bytes32",
+                internalType: "bytes32",
+            },
         ],
-        outputs: [{ name: "_amount", type: "uint256", internalType: "uint256" }],
+        outputs: [
+            {
+                name: "_amount",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
         stateMutability: "view",
     },
     {
         type: "function",
         name: "claimEscalationReward",
         inputs: [
-            { name: "_disputeId", type: "bytes32", internalType: "bytes32" },
-            { name: "_pledger", type: "address", internalType: "address" },
+            {
+                name: "_disputeId",
+                type: "bytes32",
+                internalType: "bytes32",
+            },
+            {
+                name: "_pledger",
+                type: "address",
+                internalType: "address",
+            },
         ],
         outputs: [],
         stateMutability: "nonpayable",
     },
     {
         type: "function",
-        name: "escalationResults",
-        inputs: [{ name: "_disputeId", type: "bytes32", internalType: "bytes32" }],
+        name: "disputeBalance",
+        inputs: [
+            {
+                name: "_disputeId",
+                type: "bytes32",
+                internalType: "bytes32",
+            },
+        ],
         outputs: [
-            { name: "requestId", type: "bytes32", internalType: "bytes32" },
-            { name: "amountPerPledger", type: "uint256", internalType: "uint256" },
-            { name: "bondSize", type: "uint256", internalType: "uint256" },
+            {
+                name: "_balance",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "escalationResults",
+        inputs: [
+            {
+                name: "_disputeId",
+                type: "bytes32",
+                internalType: "bytes32",
+            },
+        ],
+        outputs: [
+            {
+                name: "requestId",
+                type: "bytes32",
+                internalType: "bytes32",
+            },
+            {
+                name: "amountPerPledger",
+                type: "uint256",
+                internalType: "uint256",
+            },
+            {
+                name: "bondSize",
+                type: "uint256",
+                internalType: "uint256",
+            },
             {
                 name: "bondEscalationModule",
                 type: "address",
                 internalType: "contract IBondEscalationModule",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "getEscalationResult",
+        inputs: [
+            {
+                name: "_disputeId",
+                type: "bytes32",
+                internalType: "bytes32",
+            },
+        ],
+        outputs: [
+            {
+                name: "_escalationResult",
+                type: "tuple",
+                internalType: "struct IHorizonAccountingExtension.EscalationResult",
+                components: [
+                    {
+                        name: "requestId",
+                        type: "bytes32",
+                        internalType: "bytes32",
+                    },
+                    {
+                        name: "amountPerPledger",
+                        type: "uint256",
+                        internalType: "uint256",
+                    },
+                    {
+                        name: "bondSize",
+                        type: "uint256",
+                        internalType: "uint256",
+                    },
+                    {
+                        name: "bondEscalationModule",
+                        type: "address",
+                        internalType: "contract IBondEscalationModule",
+                    },
+                ],
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "maxUsersToCheck",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "uint128",
+                internalType: "uint128",
             },
         ],
         stateMutability: "view",
@@ -140,18 +401,66 @@ export const horizonAccountingExtensionAbi = [
                 type: "tuple",
                 internalType: "struct IOracle.Request",
                 components: [
-                    { name: "nonce", type: "uint96", internalType: "uint96" },
-                    { name: "requester", type: "address", internalType: "address" },
-                    { name: "requestModule", type: "address", internalType: "address" },
-                    { name: "responseModule", type: "address", internalType: "address" },
-                    { name: "disputeModule", type: "address", internalType: "address" },
-                    { name: "resolutionModule", type: "address", internalType: "address" },
-                    { name: "finalityModule", type: "address", internalType: "address" },
-                    { name: "requestModuleData", type: "bytes", internalType: "bytes" },
-                    { name: "responseModuleData", type: "bytes", internalType: "bytes" },
-                    { name: "disputeModuleData", type: "bytes", internalType: "bytes" },
-                    { name: "resolutionModuleData", type: "bytes", internalType: "bytes" },
-                    { name: "finalityModuleData", type: "bytes", internalType: "bytes" },
+                    {
+                        name: "nonce",
+                        type: "uint96",
+                        internalType: "uint96",
+                    },
+                    {
+                        name: "requester",
+                        type: "address",
+                        internalType: "address",
+                    },
+                    {
+                        name: "requestModule",
+                        type: "address",
+                        internalType: "address",
+                    },
+                    {
+                        name: "responseModule",
+                        type: "address",
+                        internalType: "address",
+                    },
+                    {
+                        name: "disputeModule",
+                        type: "address",
+                        internalType: "address",
+                    },
+                    {
+                        name: "resolutionModule",
+                        type: "address",
+                        internalType: "address",
+                    },
+                    {
+                        name: "finalityModule",
+                        type: "address",
+                        internalType: "address",
+                    },
+                    {
+                        name: "requestModuleData",
+                        type: "bytes",
+                        internalType: "bytes",
+                    },
+                    {
+                        name: "responseModuleData",
+                        type: "bytes",
+                        internalType: "bytes",
+                    },
+                    {
+                        name: "disputeModuleData",
+                        type: "bytes",
+                        internalType: "bytes",
+                    },
+                    {
+                        name: "resolutionModuleData",
+                        type: "bytes",
+                        internalType: "bytes",
+                    },
+                    {
+                        name: "finalityModuleData",
+                        type: "bytes",
+                        internalType: "bytes",
+                    },
                 ],
             },
             {
@@ -159,14 +468,43 @@ export const horizonAccountingExtensionAbi = [
                 type: "tuple",
                 internalType: "struct IOracle.Dispute",
                 components: [
-                    { name: "disputer", type: "address", internalType: "address" },
-                    { name: "proposer", type: "address", internalType: "address" },
-                    { name: "responseId", type: "bytes32", internalType: "bytes32" },
-                    { name: "requestId", type: "bytes32", internalType: "bytes32" },
+                    {
+                        name: "disputer",
+                        type: "address",
+                        internalType: "address",
+                    },
+                    {
+                        name: "proposer",
+                        type: "address",
+                        internalType: "address",
+                    },
+                    {
+                        name: "responseId",
+                        type: "bytes32",
+                        internalType: "bytes32",
+                    },
+                    {
+                        name: "requestId",
+                        type: "bytes32",
+                        internalType: "bytes32",
+                    },
                 ],
             },
-            { name: "_amountPerPledger", type: "uint256", internalType: "uint256" },
-            { name: "_winningPledgersLength", type: "uint256", internalType: "uint256" },
+            {
+                name: "",
+                type: "address",
+                internalType: "contract IERC20",
+            },
+            {
+                name: "_amountPerPledger",
+                type: "uint256",
+                internalType: "uint256",
+            },
+            {
+                name: "_winningPledgersLength",
+                type: "uint256",
+                internalType: "uint256",
+            },
         ],
         outputs: [],
         stateMutability: "nonpayable",
@@ -175,10 +513,31 @@ export const horizonAccountingExtensionAbi = [
         type: "function",
         name: "pay",
         inputs: [
-            { name: "_requestId", type: "bytes32", internalType: "bytes32" },
-            { name: "_payer", type: "address", internalType: "address" },
-            { name: "_receiver", type: "address", internalType: "address" },
-            { name: "_amount", type: "uint256", internalType: "uint256" },
+            {
+                name: "_requestId",
+                type: "bytes32",
+                internalType: "bytes32",
+            },
+            {
+                name: "_payer",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "_receiver",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "",
+                type: "address",
+                internalType: "contract IERC20",
+            },
+            {
+                name: "_amount",
+                type: "uint256",
+                internalType: "uint256",
+            },
         ],
         outputs: [],
         stateMutability: "nonpayable",
@@ -187,24 +546,76 @@ export const horizonAccountingExtensionAbi = [
         type: "function",
         name: "pledge",
         inputs: [
-            { name: "_pledger", type: "address", internalType: "address" },
+            {
+                name: "_pledger",
+                type: "address",
+                internalType: "address",
+            },
             {
                 name: "_request",
                 type: "tuple",
                 internalType: "struct IOracle.Request",
                 components: [
-                    { name: "nonce", type: "uint96", internalType: "uint96" },
-                    { name: "requester", type: "address", internalType: "address" },
-                    { name: "requestModule", type: "address", internalType: "address" },
-                    { name: "responseModule", type: "address", internalType: "address" },
-                    { name: "disputeModule", type: "address", internalType: "address" },
-                    { name: "resolutionModule", type: "address", internalType: "address" },
-                    { name: "finalityModule", type: "address", internalType: "address" },
-                    { name: "requestModuleData", type: "bytes", internalType: "bytes" },
-                    { name: "responseModuleData", type: "bytes", internalType: "bytes" },
-                    { name: "disputeModuleData", type: "bytes", internalType: "bytes" },
-                    { name: "resolutionModuleData", type: "bytes", internalType: "bytes" },
-                    { name: "finalityModuleData", type: "bytes", internalType: "bytes" },
+                    {
+                        name: "nonce",
+                        type: "uint96",
+                        internalType: "uint96",
+                    },
+                    {
+                        name: "requester",
+                        type: "address",
+                        internalType: "address",
+                    },
+                    {
+                        name: "requestModule",
+                        type: "address",
+                        internalType: "address",
+                    },
+                    {
+                        name: "responseModule",
+                        type: "address",
+                        internalType: "address",
+                    },
+                    {
+                        name: "disputeModule",
+                        type: "address",
+                        internalType: "address",
+                    },
+                    {
+                        name: "resolutionModule",
+                        type: "address",
+                        internalType: "address",
+                    },
+                    {
+                        name: "finalityModule",
+                        type: "address",
+                        internalType: "address",
+                    },
+                    {
+                        name: "requestModuleData",
+                        type: "bytes",
+                        internalType: "bytes",
+                    },
+                    {
+                        name: "responseModuleData",
+                        type: "bytes",
+                        internalType: "bytes",
+                    },
+                    {
+                        name: "disputeModuleData",
+                        type: "bytes",
+                        internalType: "bytes",
+                    },
+                    {
+                        name: "resolutionModuleData",
+                        type: "bytes",
+                        internalType: "bytes",
+                    },
+                    {
+                        name: "finalityModuleData",
+                        type: "bytes",
+                        internalType: "bytes",
+                    },
                 ],
             },
             {
@@ -212,13 +623,38 @@ export const horizonAccountingExtensionAbi = [
                 type: "tuple",
                 internalType: "struct IOracle.Dispute",
                 components: [
-                    { name: "disputer", type: "address", internalType: "address" },
-                    { name: "proposer", type: "address", internalType: "address" },
-                    { name: "responseId", type: "bytes32", internalType: "bytes32" },
-                    { name: "requestId", type: "bytes32", internalType: "bytes32" },
+                    {
+                        name: "disputer",
+                        type: "address",
+                        internalType: "address",
+                    },
+                    {
+                        name: "proposer",
+                        type: "address",
+                        internalType: "address",
+                    },
+                    {
+                        name: "responseId",
+                        type: "bytes32",
+                        internalType: "bytes32",
+                    },
+                    {
+                        name: "requestId",
+                        type: "bytes32",
+                        internalType: "bytes32",
+                    },
                 ],
             },
-            { name: "_amount", type: "uint256", internalType: "uint256" },
+            {
+                name: "",
+                type: "address",
+                internalType: "contract IERC20",
+            },
+            {
+                name: "_amount",
+                type: "uint256",
+                internalType: "uint256",
+            },
         ],
         outputs: [],
         stateMutability: "nonpayable",
@@ -227,66 +663,69 @@ export const horizonAccountingExtensionAbi = [
         type: "function",
         name: "pledgerClaimed",
         inputs: [
-            { name: "_requestId", type: "bytes32", internalType: "bytes32" },
-            { name: "_pledger", type: "address", internalType: "address" },
+            {
+                name: "_requestId",
+                type: "bytes32",
+                internalType: "bytes32",
+            },
+            {
+                name: "_pledger",
+                type: "address",
+                internalType: "address",
+            },
         ],
-        outputs: [{ name: "_claimed", type: "bool", internalType: "bool" }],
+        outputs: [
+            {
+                name: "_claimed",
+                type: "bool",
+                internalType: "bool",
+            },
+        ],
         stateMutability: "view",
     },
     {
         type: "function",
         name: "pledges",
-        inputs: [{ name: "_disputeId", type: "bytes32", internalType: "bytes32" }],
-        outputs: [{ name: "_amount", type: "uint256", internalType: "uint256" }],
+        inputs: [
+            {
+                name: "_disputeId",
+                type: "bytes32",
+                internalType: "bytes32",
+            },
+        ],
+        outputs: [
+            {
+                name: "_amount",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
         stateMutability: "view",
     },
     {
         type: "function",
         name: "release",
         inputs: [
-            { name: "_bonder", type: "address", internalType: "address" },
-            { name: "_requestId", type: "bytes32", internalType: "bytes32" },
-            { name: "_amount", type: "uint256", internalType: "uint256" },
-        ],
-        outputs: [],
-        stateMutability: "nonpayable",
-    },
-    {
-        type: "function",
-        name: "releasePledge",
-        inputs: [
             {
-                name: "_request",
-                type: "tuple",
-                internalType: "struct IOracle.Request",
-                components: [
-                    { name: "nonce", type: "uint96", internalType: "uint96" },
-                    { name: "requester", type: "address", internalType: "address" },
-                    { name: "requestModule", type: "address", internalType: "address" },
-                    { name: "responseModule", type: "address", internalType: "address" },
-                    { name: "disputeModule", type: "address", internalType: "address" },
-                    { name: "resolutionModule", type: "address", internalType: "address" },
-                    { name: "finalityModule", type: "address", internalType: "address" },
-                    { name: "requestModuleData", type: "bytes", internalType: "bytes" },
-                    { name: "responseModuleData", type: "bytes", internalType: "bytes" },
-                    { name: "disputeModuleData", type: "bytes", internalType: "bytes" },
-                    { name: "resolutionModuleData", type: "bytes", internalType: "bytes" },
-                    { name: "finalityModuleData", type: "bytes", internalType: "bytes" },
-                ],
+                name: "_bonder",
+                type: "address",
+                internalType: "address",
             },
             {
-                name: "_dispute",
-                type: "tuple",
-                internalType: "struct IOracle.Dispute",
-                components: [
-                    { name: "disputer", type: "address", internalType: "address" },
-                    { name: "proposer", type: "address", internalType: "address" },
-                    { name: "responseId", type: "bytes32", internalType: "bytes32" },
-                    { name: "requestId", type: "bytes32", internalType: "bytes32" },
-                ],
+                name: "_requestId",
+                type: "bytes32",
+                internalType: "bytes32",
             },
-            { name: "_pledger", type: "address", internalType: "address" },
-            { name: "_amount", type: "uint256", internalType: "uint256" },
+            {
+                name: "",
+                type: "address",
+                internalType: "contract IERC20",
+            },
+            {
+                name: "_amount",
+                type: "uint256",
+                internalType: "uint256",
+            },
         ],
         outputs: [],
         stateMutability: "nonpayable",
@@ -294,7 +733,26 @@ export const horizonAccountingExtensionAbi = [
     {
         type: "function",
         name: "revokeModule",
-        inputs: [{ name: "_module", type: "address", internalType: "address" }],
+        inputs: [
+            {
+                name: "_module",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "setMaxUsersToCheck",
+        inputs: [
+            {
+                name: "_maxUsersToCheck",
+                type: "uint128",
+                internalType: "uint128",
+            },
+        ],
         outputs: [],
         stateMutability: "nonpayable",
     },
@@ -302,9 +760,21 @@ export const horizonAccountingExtensionAbi = [
         type: "function",
         name: "slash",
         inputs: [
-            { name: "_disputeId", type: "bytes32", internalType: "bytes32" },
-            { name: "_usersToSlash", type: "uint256", internalType: "uint256" },
-            { name: "_maxUsersToCheck", type: "uint256", internalType: "uint256" },
+            {
+                name: "_disputeId",
+                type: "bytes32",
+                internalType: "bytes32",
+            },
+            {
+                name: "_usersToSlash",
+                type: "uint256",
+                internalType: "uint256",
+            },
+            {
+                name: "_maxUsersToCheck",
+                type: "uint256",
+                internalType: "uint256",
+            },
         ],
         outputs: [],
         stateMutability: "nonpayable",
@@ -312,17 +782,44 @@ export const horizonAccountingExtensionAbi = [
     {
         type: "function",
         name: "totalBonded",
-        inputs: [{ name: "_user", type: "address", internalType: "address" }],
-        outputs: [{ name: "_bonded", type: "uint256", internalType: "uint256" }],
+        inputs: [
+            {
+                name: "_user",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "_bonded",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
         stateMutability: "view",
     },
     {
         type: "event",
         name: "BondEscalationSettled",
         inputs: [
-            { name: "_requestId", type: "bytes32", indexed: false, internalType: "bytes32" },
-            { name: "_disputeId", type: "bytes32", indexed: false, internalType: "bytes32" },
-            { name: "_amountPerPledger", type: "uint256", indexed: false, internalType: "uint256" },
+            {
+                name: "_requestId",
+                type: "bytes32",
+                indexed: false,
+                internalType: "bytes32",
+            },
+            {
+                name: "_disputeId",
+                type: "bytes32",
+                indexed: false,
+                internalType: "bytes32",
+            },
+            {
+                name: "_amountPerPledger",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
             {
                 name: "_winningPledgersLength",
                 type: "uint256",
@@ -336,9 +833,24 @@ export const horizonAccountingExtensionAbi = [
         type: "event",
         name: "Bonded",
         inputs: [
-            { name: "_requestId", type: "bytes32", indexed: true, internalType: "bytes32" },
-            { name: "_bonder", type: "address", indexed: true, internalType: "address" },
-            { name: "_amount", type: "uint256", indexed: false, internalType: "uint256" },
+            {
+                name: "_requestId",
+                type: "bytes32",
+                indexed: true,
+                internalType: "bytes32",
+            },
+            {
+                name: "_bonder",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "_amount",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
         ],
         anonymous: false,
     },
@@ -346,11 +858,49 @@ export const horizonAccountingExtensionAbi = [
         type: "event",
         name: "EscalationRewardClaimed",
         inputs: [
-            { name: "_requestId", type: "bytes32", indexed: true, internalType: "bytes32" },
-            { name: "_disputeId", type: "bytes32", indexed: true, internalType: "bytes32" },
-            { name: "_pledger", type: "address", indexed: true, internalType: "address" },
-            { name: "_reward", type: "uint256", indexed: false, internalType: "uint256" },
-            { name: "_released", type: "uint256", indexed: false, internalType: "uint256" },
+            {
+                name: "_requestId",
+                type: "bytes32",
+                indexed: true,
+                internalType: "bytes32",
+            },
+            {
+                name: "_disputeId",
+                type: "bytes32",
+                indexed: true,
+                internalType: "bytes32",
+            },
+            {
+                name: "_pledger",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "_reward",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+            {
+                name: "_released",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "MaxUsersToCheckSet",
+        inputs: [
+            {
+                name: "_maxUsersToCheck",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
         ],
         anonymous: false,
     },
@@ -358,21 +908,30 @@ export const horizonAccountingExtensionAbi = [
         type: "event",
         name: "Paid",
         inputs: [
-            { name: "_requestId", type: "bytes32", indexed: true, internalType: "bytes32" },
-            { name: "_beneficiary", type: "address", indexed: true, internalType: "address" },
-            { name: "_payer", type: "address", indexed: true, internalType: "address" },
-            { name: "_amount", type: "uint256", indexed: false, internalType: "uint256" },
-        ],
-        anonymous: false,
-    },
-    {
-        type: "event",
-        name: "PledgeReleased",
-        inputs: [
-            { name: "_requestId", type: "bytes32", indexed: true, internalType: "bytes32" },
-            { name: "_disputeId", type: "bytes32", indexed: true, internalType: "bytes32" },
-            { name: "_pledger", type: "address", indexed: true, internalType: "address" },
-            { name: "_amount", type: "uint256", indexed: false, internalType: "uint256" },
+            {
+                name: "_requestId",
+                type: "bytes32",
+                indexed: true,
+                internalType: "bytes32",
+            },
+            {
+                name: "_beneficiary",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "_payer",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "_amount",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
         ],
         anonymous: false,
     },
@@ -380,10 +939,30 @@ export const horizonAccountingExtensionAbi = [
         type: "event",
         name: "Pledged",
         inputs: [
-            { name: "_pledger", type: "address", indexed: true, internalType: "address" },
-            { name: "_requestId", type: "bytes32", indexed: true, internalType: "bytes32" },
-            { name: "_disputeId", type: "bytes32", indexed: true, internalType: "bytes32" },
-            { name: "_amount", type: "uint256", indexed: false, internalType: "uint256" },
+            {
+                name: "_pledger",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "_requestId",
+                type: "bytes32",
+                indexed: true,
+                internalType: "bytes32",
+            },
+            {
+                name: "_disputeId",
+                type: "bytes32",
+                indexed: true,
+                internalType: "bytes32",
+            },
+            {
+                name: "_amount",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
         ],
         anonymous: false,
     },
@@ -391,9 +970,24 @@ export const horizonAccountingExtensionAbi = [
         type: "event",
         name: "Released",
         inputs: [
-            { name: "_requestId", type: "bytes32", indexed: true, internalType: "bytes32" },
-            { name: "_beneficiary", type: "address", indexed: true, internalType: "address" },
-            { name: "_amount", type: "uint256", indexed: false, internalType: "uint256" },
+            {
+                name: "_requestId",
+                type: "bytes32",
+                indexed: true,
+                internalType: "bytes32",
+            },
+            {
+                name: "_beneficiary",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "_amount",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
         ],
         anonymous: false,
     },
@@ -401,30 +995,106 @@ export const horizonAccountingExtensionAbi = [
         type: "event",
         name: "WinningPledgersPaid",
         inputs: [
-            { name: "_requestId", type: "bytes32", indexed: true, internalType: "bytes32" },
-            { name: "_disputeId", type: "bytes32", indexed: true, internalType: "bytes32" },
+            {
+                name: "_requestId",
+                type: "bytes32",
+                indexed: true,
+                internalType: "bytes32",
+            },
+            {
+                name: "_disputeId",
+                type: "bytes32",
+                indexed: true,
+                internalType: "bytes32",
+            },
             {
                 name: "_winningPledgers",
                 type: "address[]",
                 indexed: true,
                 internalType: "address[]",
             },
-            { name: "_amountPerPledger", type: "uint256", indexed: false, internalType: "uint256" },
+            {
+                name: "_amountPerPledger",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
         ],
         anonymous: false,
     },
-    { type: "error", name: "HorizonAccountingExtension_AlreadyClaimed", inputs: [] },
-    { type: "error", name: "HorizonAccountingExtension_AlreadySettled", inputs: [] },
-    { type: "error", name: "HorizonAccountingExtension_FeeOnTransferToken", inputs: [] },
-    { type: "error", name: "HorizonAccountingExtension_InsufficientBondedTokens", inputs: [] },
-    { type: "error", name: "HorizonAccountingExtension_InsufficientFunds", inputs: [] },
-    { type: "error", name: "HorizonAccountingExtension_InsufficientTokens", inputs: [] },
-    { type: "error", name: "HorizonAccountingExtension_InvalidMaxVerifierCut", inputs: [] },
-    { type: "error", name: "HorizonAccountingExtension_InvalidThawingPeriod", inputs: [] },
-    { type: "error", name: "HorizonAccountingExtension_NoEscalationResult", inputs: [] },
-    { type: "error", name: "HorizonAccountingExtension_NotAllowed", inputs: [] },
-    { type: "error", name: "HorizonAccountingExtension_UnauthorizedModule", inputs: [] },
-    { type: "error", name: "HorizonAccountingExtension_UnauthorizedUser", inputs: [] },
-    { type: "error", name: "Validator_InvalidDispute", inputs: [] },
-    { type: "error", name: "Validator_InvalidResponse", inputs: [] },
+    {
+        type: "error",
+        name: "HorizonAccountingExtension_AlreadyClaimed",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "HorizonAccountingExtension_AlreadySettled",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "HorizonAccountingExtension_FeeOnTransferToken",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "HorizonAccountingExtension_InsufficientBondedTokens",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "HorizonAccountingExtension_InsufficientFunds",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "HorizonAccountingExtension_InsufficientTokens",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "HorizonAccountingExtension_InvalidMaxVerifierCut",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "HorizonAccountingExtension_InvalidThawingPeriod",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "HorizonAccountingExtension_NoEscalationResult",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "HorizonAccountingExtension_NotAllowed",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "HorizonAccountingExtension_UnauthorizedCaller",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "HorizonAccountingExtension_UnauthorizedModule",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "HorizonAccountingExtension_UnauthorizedUser",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "Validator_InvalidDispute",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "Validator_InvalidResponse",
+        inputs: [],
+    },
 ] as const;

--- a/packages/automated-dispute/src/providers/protocolProvider.ts
+++ b/packages/automated-dispute/src/providers/protocolProvider.ts
@@ -1,3 +1,4 @@
+import { UnsupportedChain } from "@ebo-agent/blocknumber";
 import { Caip2ChainId, UnixTimestamp } from "@ebo-agent/shared";
 import {
     AbiEvent,
@@ -23,7 +24,7 @@ import {
     WalletClient,
 } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
-import { arbitrum, mainnet } from "viem/chains";
+import { arbitrum, arbitrumSepolia, mainnet, sepolia } from "viem/chains";
 
 import type {
     Dispute,
@@ -59,6 +60,7 @@ import {
 } from "../interfaces/index.js";
 
 type RpcConfig = {
+    chainId: Caip2ChainId;
     urls: string[];
     transactionReceiptConfirmations: number;
     timeout: number;
@@ -136,9 +138,12 @@ export class ProtocolProvider implements IProtocolProvider {
         contracts: ProtocolContractsAddresses,
         privateKey: Hex,
     ) {
-        this.l1ReadClient = this.createReadClient(rpcConfig.l1, mainnet);
-        this.l2ReadClient = this.createReadClient(rpcConfig.l2, arbitrum);
-        this.l2WriteClient = this.createWriteClient(rpcConfig.l2, arbitrum, privateKey);
+        const l1Chain = this.getViemChain(rpcConfig.l1.chainId);
+        const l2Chain = this.getViemChain(rpcConfig.l2.chainId);
+
+        this.l1ReadClient = this.createReadClient(rpcConfig.l1, l1Chain);
+        this.l2ReadClient = this.createReadClient(rpcConfig.l2, l2Chain);
+        this.l2WriteClient = this.createWriteClient(rpcConfig.l2, l2Chain, privateKey);
 
         // Instantiate all the protocol contracts
         this.oracleContract = getContract({
@@ -254,6 +259,25 @@ export class ProtocolProvider implements IProtocolProvider {
             ),
             account: account,
         });
+    }
+
+    private getViemChain(chainId: Caip2ChainId): Chain {
+        switch (chainId) {
+            case "eip155:1":
+                return mainnet;
+
+            case "eip155:11155111":
+                return sepolia;
+
+            case "eip155:42161":
+                return arbitrum;
+
+            case "eip155:421614":
+                return arbitrumSepolia;
+
+            default:
+                throw new UnsupportedChain(chainId);
+        }
     }
 
     /**
@@ -453,6 +477,7 @@ export class ProtocolProvider implements IProtocolProvider {
                     requestId: event.args._requestId,
                     epoch: event.args._epoch,
                     chainId: event.args._chainId,
+                    request: event.args._request,
                 },
             } as unknown as EboEvent<"RequestCreated">;
         });
@@ -505,7 +530,7 @@ export class ProtocolProvider implements IProtocolProvider {
     // TODO: use Caip2 Chain ID instead of string in return type
     async getAvailableChains(): Promise<Caip2ChainId[]> {
         // TODO: implement actual method
-        return ["eip155:42161"];
+        return ["eip155:421614"];
     }
 
     getAccountingModuleAddress(): Address {

--- a/packages/automated-dispute/src/services/eboProcessor.ts
+++ b/packages/automated-dispute/src/services/eboProcessor.ts
@@ -136,7 +136,7 @@ export class EboProcessor {
 
             await Promise.all(synchedRequests);
 
-            this.logger.info(`Consumed events up to block ${lastBlock}.`);
+            this.logger.info(`Consumed events up to block ${lastBlock.number}.`);
 
             this.createMissingRequests(currentEpoch.number);
 
@@ -180,7 +180,7 @@ export class EboProcessor {
 
         const lastBlock = await this.protocolProvider.getLastFinalizedBlock();
 
-        this.logger.info(`Last finalized block ${lastBlock} fetched.`);
+        this.logger.info(`Last finalized block ${lastBlock.number} fetched.`);
 
         return lastBlock;
     }
@@ -196,6 +196,8 @@ export class EboProcessor {
         this.logger.info(`Fetching events between blocks ${fromBlock} and ${toBlock}...`);
 
         const events = await this.protocolProvider.getEvents(fromBlock, toBlock);
+
+        // TODO: add a logger.debug of all the fetched events, super useful during debugging
 
         this.logger.info(`${events.length} events fetched.`);
 

--- a/packages/automated-dispute/src/services/eboRegistry/commands/addRequest.ts
+++ b/packages/automated-dispute/src/services/eboRegistry/commands/addRequest.ts
@@ -18,7 +18,6 @@ export class AddRequest implements EboRegistryCommand {
         event: EboEvent<"RequestCreated">,
         registry: EboRegistry,
     ): AddRequest {
-        // @ts-expect-error: must fetch request differently
         const eventRequest = event.metadata.request;
         const chainId = Caip2Utils.findByHash(event.metadata.chainId);
 
@@ -42,7 +41,6 @@ export class AddRequest implements EboRegistryCommand {
                     eventRequest.responseModuleData,
                 ),
             },
-            // @ts-expect-error: must fetch request
             prophetData: event.metadata.request,
             status: "Active",
         };

--- a/packages/automated-dispute/src/types/events.ts
+++ b/packages/automated-dispute/src/types/events.ts
@@ -1,7 +1,15 @@
 import { UnixTimestamp } from "@ebo-agent/shared";
 import { Address, Hex, Log } from "viem";
 
-import { Dispute, DisputeId, DisputeStatus, RequestId, Response, ResponseId } from "./prophet.js";
+import {
+    Dispute,
+    DisputeId,
+    DisputeStatus,
+    Request,
+    RequestId,
+    Response,
+    ResponseId,
+} from "./prophet.js";
 
 export type EboEventName =
     | "RequestCreated"
@@ -11,16 +19,17 @@ export type EboEventName =
     | "DisputeEscalated"
     | "OracleRequestFinalized";
 
-export interface ResponseProposed {
-    requestId: Hex;
-    responseId: Hex;
-    response: Response["prophetData"];
-}
-
 export interface RequestCreated {
     epoch: bigint;
     chainId: Hex; // keccak256 CAIP-2 chain ID
     requestId: RequestId;
+    request: Request["prophetData"];
+}
+
+export interface ResponseProposed {
+    requestId: Hex;
+    responseId: Hex;
+    response: Response["prophetData"];
 }
 
 export interface ResponseDisputed {

--- a/packages/automated-dispute/tests/mocks/eboActor.mocks.ts
+++ b/packages/automated-dispute/tests/mocks/eboActor.mocks.ts
@@ -33,12 +33,14 @@ export function buildEboActor(request: Request, logger: ILogger) {
     const protocolProvider = new ProtocolProvider(
         {
             l1: {
+                chainId: "eip155:1",
                 urls: ["http://localhost:8545"],
                 retryInterval: 1,
                 timeout: 100,
                 transactionReceiptConfirmations: 1,
             },
             l2: {
+                chainId: "eip155:42161",
                 urls: ["http://localhost:8546"],
                 retryInterval: 1,
                 timeout: 100,

--- a/packages/automated-dispute/tests/mocks/eboProcessor.mocks.ts
+++ b/packages/automated-dispute/tests/mocks/eboProcessor.mocks.ts
@@ -23,12 +23,14 @@ export function buildEboProcessor(
     const protocolProvider = new ProtocolProvider(
         {
             l1: {
+                chainId: "eip155:1",
                 urls: ["http://localhost:8538"],
                 retryInterval: 1,
                 timeout: 100,
                 transactionReceiptConfirmations: 1,
             },
             l2: {
+                chainId: "eip155:42161",
                 urls: ["http://localhost:8539"],
                 retryInterval: 1,
                 timeout: 100,

--- a/packages/automated-dispute/tests/services/eboActorsManager.spec.ts
+++ b/packages/automated-dispute/tests/services/eboActorsManager.spec.ts
@@ -36,12 +36,14 @@ describe("EboActorsManager", () => {
         protocolProvider = new ProtocolProvider(
             {
                 l1: {
+                    chainId: "eip155:1",
                     urls: ["http://localhost:8538"],
                     retryInterval: 1,
                     timeout: 100,
                     transactionReceiptConfirmations: 1,
                 },
                 l2: {
+                    chainId: "eip155:42161",
                     urls: ["http://localhost:8539"],
                     retryInterval: 1,
                     timeout: 100,

--- a/packages/automated-dispute/tests/services/protocolProvider.spec.ts
+++ b/packages/automated-dispute/tests/services/protocolProvider.spec.ts
@@ -1,16 +1,12 @@
 import { Caip2ChainId } from "@ebo-agent/shared";
 import {
-    AbiEvent,
     ContractFunctionRevertedError,
     createPublicClient,
     createWalletClient,
-    encodeAbiParameters,
     fallback,
     getContract,
-    getEventSelector,
     http,
     isHex,
-    keccak256,
     Log,
     WaitForTransactionReceiptTimeoutError,
 } from "viem";
@@ -853,96 +849,6 @@ describe("ProtocolProvider", () => {
             await expect(protocolProvider.getApprovedModules(mockUserAddress)).rejects.toThrow(
                 error,
             );
-        });
-    });
-
-    describe("decodeLogData", () => {
-        it("successfully decodes RequestCreated event", () => {
-            const protocolProvider = new ProtocolProvider(
-                mockRpcConfig,
-                mockContractAddress,
-                mockedPrivateKey,
-            );
-
-            const eboRequestCreatorAbi = [
-                {
-                    type: "event",
-                    name: "RequestCreated",
-                    inputs: [
-                        {
-                            name: "_requestId",
-                            type: "bytes32",
-                            indexed: true,
-                            internalType: "bytes32",
-                        },
-                        { name: "_epoch", type: "uint256", indexed: true, internalType: "uint256" },
-                        { name: "_chainId", type: "string", indexed: true, internalType: "string" },
-                    ],
-                    anonymous: false,
-                },
-            ];
-
-            const eventAbi = eboRequestCreatorAbi[0];
-            const eventSignature = getEventSelector(eventAbi as AbiEvent);
-
-            const _requestId = "0x" + "123".padStart(64, "0");
-            const _epoch = 1n;
-            const _chainId = "eip155:1";
-
-            const epochHex = "0x" + _epoch.toString(16).padStart(64, "0");
-            const chainIdHash = keccak256(encodeAbiParameters([{ type: "string" }], [_chainId]));
-
-            const topics = [eventSignature, _requestId, epochHex, chainIdHash] as [
-                `0x${string}`,
-                ...`0x${string}`[],
-            ];
-
-            const mockLog: Log = {
-                address: "0x1234567890123456789012345678901234567890",
-                topics,
-                data: "0x",
-                blockNumber: 1n,
-                transactionHash:
-                    "0x1234567890123456789012345678901234567890123456789012345678901234",
-                transactionIndex: 1,
-                blockHash: "0x1234567890123456789012345678901234567890123456789012345678901234",
-                logIndex: 1,
-                removed: false,
-            };
-
-            const result = (protocolProvider as any).decodeLogData("RequestCreated", mockLog);
-
-            expect(result).toBeDefined();
-            expect(result).toEqual({
-                _requestId,
-                _epoch,
-                _chainId: chainIdHash,
-            });
-        });
-
-        it("throws an error for unsupported event name", () => {
-            const protocolProvider = new ProtocolProvider(
-                mockRpcConfig,
-                mockContractAddress,
-                mockedPrivateKey,
-            );
-
-            const mockLog: Log = {
-                address: "0x1234567890123456789012345678901234567890",
-                topics: ["0x0000000000000000000000000000000000000000000000000000000000000001"],
-                data: "0x",
-                blockNumber: 1n,
-                transactionHash:
-                    "0x1234567890123456789012345678901234567890123456789012345678901234",
-                transactionIndex: 1,
-                blockHash: "0x1234567890123456789012345678901234567890123456789012345678901234",
-                logIndex: 1,
-                removed: false,
-            };
-
-            expect(() =>
-                (protocolProvider as any).parseOracleEvent("UnsupportedEvent", mockLog),
-            ).toThrow("Unsupported event name: UnsupportedEvent");
         });
     });
 

--- a/packages/automated-dispute/tests/services/protocolProvider.spec.ts
+++ b/packages/automated-dispute/tests/services/protocolProvider.spec.ts
@@ -56,12 +56,14 @@ vi.mock("viem", async () => {
 describe("ProtocolProvider", () => {
     const mockRpcConfig = {
         l1: {
+            chainId: "eip155:1",
             urls: ["http://localhost:8545"],
             retryInterval: 1,
             timeout: 100,
             transactionReceiptConfirmations: 1,
         },
         l2: {
+            chainId: "eip155:42161",
             urls: ["http://localhost:8546"],
             retryInterval: 1,
             timeout: 100,

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -7,6 +7,8 @@ export const EBO_SUPPORTED_CHAINS_CONFIG = {
             ethereum: "1",
             polygon: "137",
             arbitrum: "42161",
+            arbitrumSepolia: "421614",
+            arbitrumAnvil: "4216138",
         },
     },
     solana: {


### PR DESCRIPTION
# 🤖 Linear

Closes GRT-205

Part of GRT-191

## Description
Super complete PR. Had to fix some stuff due to changes on contracts + changes on on-chain deployment scripts. There are some extra fixes/improvements that I've seen during the debugging of horizon setup.

* Config and support for new Horizon staking contracts in E2E (now using Sepolia)
* Update RpcConfig with chain IDs to use for L1 and L2 in protocol provider
* Improved typing using `AnvilClient` wherever it's possible
* Updated the deploy script in E2E to use `forge` directly instead of `yarn`
* Use `EBORequestCreator`'s `RequestCreated` request field
* Fixed some logs re: block numbers not being displayed correctly (ie `[object Object]` instead of `1234`)

There are some more changes incoming but I had to stop at some point lol