### PR TITLE
fix: consume Oracle RequestCreated event

### DIFF
--- a/packages/automated-dispute/src/exceptions/responseAlreadyProposed.exception.ts
+++ b/packages/automated-dispute/src/exceptions/responseAlreadyProposed.exception.ts
@@ -2,8 +2,10 @@ import { Request, ResponseBody } from "../types/prophet.js";
 
 export class ResponseAlreadyProposed extends Error {
     constructor(request: Request, response: ResponseBody) {
+        const { epoch, chainId } = request.decodedData.requestModuleData;
+
         super(
-            `Block ${response.block} was already proposed for epoch ${request.epoch} on chain ${request.chainId}`,
+            `Block ${response.block} was already proposed for epoch ${epoch} on chain ${chainId}`,
         );
 
         this.name = "ResponseAlreadyProposed";

--- a/packages/automated-dispute/src/services/eboProcessor.ts
+++ b/packages/automated-dispute/src/services/eboProcessor.ts
@@ -21,6 +21,7 @@ import {
     RequestId,
 } from "../types/index.js";
 import { EboActorsManager } from "./eboActorsManager.js";
+import { ProphetCodec } from "./prophetCodec.js";
 
 const DEFAULT_MS_BETWEEN_CHECKS = 10 * 60 * 1000; // 10 minutes
 
@@ -286,12 +287,16 @@ export class EboProcessor {
         if (actor) return actor;
 
         if (firstEvent && isRequestCreatedEvent(firstEvent)) {
-            const hashedChainId = firstEvent.metadata.chainId;
-            const chainId = Caip2Utils.findByHash(hashedChainId);
+            const requestModuleData = ProphetCodec.decodeRequestRequestModuleData(
+                firstEvent.metadata.request.requestModuleData,
+            );
 
-            if (chainId) {
+            const { chainId, epoch } = requestModuleData;
+
+            const isChainSupported = Caip2Utils.isSupported(chainId);
+
+            if (isChainSupported) {
                 const requestId = HexUtils.normalize(firstEvent.requestId) as RequestId;
-                const epoch = firstEvent.metadata.epoch;
 
                 this.logger.info(`Creating a new EboActor to handle request ${requestId}...`);
 

--- a/packages/automated-dispute/src/services/eboRegistry/commands/addResponse.ts
+++ b/packages/automated-dispute/src/services/eboRegistry/commands/addResponse.ts
@@ -2,8 +2,8 @@ import { HexUtils } from "@ebo-agent/shared";
 
 import { CommandAlreadyRun, CommandNotRun } from "../../../exceptions/index.js";
 import { EboRegistry, EboRegistryCommand } from "../../../interfaces/index.js";
-import { ProtocolProvider } from "../../../providers/index.js";
 import { EboEvent, Response, ResponseBody, ResponseId } from "../../../types/index.js";
+import { ProphetCodec } from "../../prophetCodec.js";
 
 export class AddResponse implements EboRegistryCommand {
     private wasRun: boolean = false;
@@ -15,7 +15,7 @@ export class AddResponse implements EboRegistryCommand {
 
     static buildFromEvent(event: EboEvent<"ResponseProposed">, registry: EboRegistry) {
         const encodedResponse = event.metadata.response.response;
-        const responseBody: ResponseBody = ProtocolProvider.decodeResponse(encodedResponse);
+        const responseBody: ResponseBody = ProphetCodec.decodeResponse(encodedResponse);
 
         const response: Response = {
             id: HexUtils.normalize(event.metadata.responseId) as ResponseId,

--- a/packages/automated-dispute/src/services/index.ts
+++ b/packages/automated-dispute/src/services/index.ts
@@ -3,3 +3,4 @@ export * from "./eboActorsManager.js";
 export * from "./eboProcessor.js";
 export * from "./eboRegistry/index.js";
 export * from "./discordNotifier.js";
+export * from "./prophetCodec.js";

--- a/packages/automated-dispute/src/services/prophetCodec.ts
+++ b/packages/automated-dispute/src/services/prophetCodec.ts
@@ -1,0 +1,188 @@
+import { Caip2ChainId } from "@ebo-agent/shared";
+import { Address, decodeAbiParameters, encodeAbiParameters } from "viem";
+
+import { Request, Response } from "../types/prophet.js";
+
+const REQUEST_REQUEST_MODULE_DATA_ABI_FIELDS = [
+    { name: "epoch", type: "uint256" },
+    { name: "chainId", type: "string" },
+    { name: "accountingExtension", type: "address" },
+    { name: "paymentAmount", type: "uint256" },
+] as const;
+
+const REQUEST_RESPONSE_MODULE_DATA_ABI_FIELDS = [
+    { name: "accountingExtension", type: "address" },
+    { name: "bondToken", type: "address" },
+    { name: "bondSize", type: "uint256" },
+    { name: "deadline", type: "uint256" },
+    { name: "disputeWindow", type: "uint256" },
+] as const;
+
+const REQUEST_DISPUTE_MODULE_DATA_ABI_FIELDS = [
+    { name: "accountingExtension", type: "address" },
+    { name: "bondToken", type: "address" },
+    { name: "bondSize", type: "uint256" },
+    { name: "maxNumberOfEscalations", type: "uint256" },
+    { name: "bondEscalationDeadline", type: "uint256" },
+    { name: "tyingBuffer", type: "uint256" },
+    { name: "disputeWindow", type: "uint256" },
+] as const;
+
+const RESPONSE_RESPONSE_ABI_FIELDS = [{ name: "block", type: "uint256" }] as const;
+
+/** Class to encode/decode Prophet's structs into/from a byte array */
+export class ProphetCodec {
+    /**
+     * Decodes the request's request module data bytes into an object.
+     *
+     * @param {Request["prophetData"]["requestModuleData"]} requestModuleData - The request module data bytes.
+     * @returns {Request["decodedData"]["requestModuleData"]} A decoded object with requestModuleData properties.
+     */
+    static decodeRequestRequestModuleData(
+        requestModuleData: Request["prophetData"]["requestModuleData"],
+    ): Request["decodedData"]["requestModuleData"] {
+        const decodeParameters = decodeAbiParameters(
+            REQUEST_REQUEST_MODULE_DATA_ABI_FIELDS,
+            requestModuleData,
+        );
+
+        return {
+            epoch: decodeParameters[0],
+            chainId: decodeParameters[1] as Caip2ChainId,
+            accountingExtension: decodeParameters[2] as Address,
+            paymentAmount: decodeParameters[3],
+        };
+    }
+
+    /**
+     * Encodes the request's request module data object into bytes.
+     *
+     * @param {Request["decodedData"]["requestModuleData"]} requestModuleData - The request's request module data object
+     * @returns {Request["prophetData"]["requestModuleData"]} A byte-encoded request module data object
+     */
+
+    static encodeRequestRequestModuleData(
+        requestModuleData: Request["decodedData"]["requestModuleData"],
+    ): Request["prophetData"]["requestModuleData"] {
+        return encodeAbiParameters(REQUEST_REQUEST_MODULE_DATA_ABI_FIELDS, [
+            requestModuleData.epoch,
+            requestModuleData.chainId,
+            requestModuleData.accountingExtension,
+            requestModuleData.paymentAmount,
+        ]);
+    }
+
+    /**
+     * Decodes the request's response module data bytes into an object.
+     *
+     * @param {Request["prophetData"]["responseModuleData"]} responseModuleData - The response module data bytes.
+     * @returns {Request["decodedData"]["responseModuleData"]} A decoded object with responseModuleData properties.
+     */
+    static decodeRequestResponseModuleData(
+        responseModuleData: Request["prophetData"]["responseModuleData"],
+    ): Request["decodedData"]["responseModuleData"] {
+        const decodedParameters = decodeAbiParameters(
+            REQUEST_RESPONSE_MODULE_DATA_ABI_FIELDS,
+            responseModuleData,
+        );
+
+        return {
+            accountingExtension: decodedParameters[0],
+            bondToken: decodedParameters[1],
+            bondSize: decodedParameters[2],
+            deadline: decodedParameters[3],
+            disputeWindow: decodedParameters[4],
+        };
+    }
+
+    /**
+     * Encodes the request's response module data object into bytes.
+     *
+     * @param {Request["decodedData"]["responseModuleData"]} responseModuleData - The request's response module data object
+     * @returns {Request["prophetData"]["responseModuleData"]} A byte-encoded response module data object
+     */
+    static encodeRequestResponseModuleData(
+        responseModuleData: Request["decodedData"]["responseModuleData"],
+    ): Request["prophetData"]["responseModuleData"] {
+        return encodeAbiParameters(REQUEST_RESPONSE_MODULE_DATA_ABI_FIELDS, [
+            responseModuleData.accountingExtension,
+            responseModuleData.bondToken,
+            responseModuleData.bondSize,
+            responseModuleData.deadline,
+            responseModuleData.disputeWindow,
+        ]);
+    }
+
+    /**
+     * Decodes the request's dispute module data bytes into an object.
+     *
+     * @param {Request["prophetData"]["disputeModuleData"]} disputeModuleData - The dispute module data bytes.
+     * @returns {Request["decodedData"]["disputeModuleData"]} A decoded object with disputeModuleData properties.
+     */
+    static decodeRequestDisputeModuleData(
+        disputeModuleData: Request["prophetData"]["disputeModuleData"],
+    ): Request["decodedData"]["disputeModuleData"] {
+        const decodedParameters = decodeAbiParameters(
+            REQUEST_DISPUTE_MODULE_DATA_ABI_FIELDS,
+            disputeModuleData,
+        );
+
+        return {
+            accountingExtension: decodedParameters[0],
+            bondToken: decodedParameters[1],
+            bondSize: decodedParameters[2],
+            maxNumberOfEscalations: decodedParameters[3],
+            bondEscalationDeadline: decodedParameters[4],
+            tyingBuffer: decodedParameters[5],
+            disputeWindow: decodedParameters[6],
+        };
+    }
+
+    /**
+     * Encodes the request's dispute module data object into bytes.
+     *
+     * @param {Request["decodedData"]["disputeModuleData"]} disputeModuleData - The request's dispute module data object
+     * @returns {Request["prophetData"]["disputeModuleData"]} A byte-encoded dispute module data object
+     */
+    static encodeRequestDisputeModuleData(
+        disputeModuleData: Request["decodedData"]["disputeModuleData"],
+    ): Request["prophetData"]["disputeModuleData"] {
+        return encodeAbiParameters(REQUEST_DISPUTE_MODULE_DATA_ABI_FIELDS, [
+            disputeModuleData.accountingExtension,
+            disputeModuleData.bondToken,
+            disputeModuleData.bondSize,
+            disputeModuleData.maxNumberOfEscalations,
+            disputeModuleData.bondEscalationDeadline,
+            disputeModuleData.tyingBuffer,
+            disputeModuleData.disputeWindow,
+        ]);
+    }
+
+    /**
+     * Encodes a response object into bytes.
+     *
+     * @param {Response["decodedData"]["response"]} response - The response object to encode.
+     * @returns {Response["prophetData"]["response"]} Byte-encoded response body.
+     */
+    static encodeResponse(
+        response: Response["decodedData"]["response"],
+    ): Response["prophetData"]["response"] {
+        return encodeAbiParameters(RESPONSE_RESPONSE_ABI_FIELDS, [response.block]);
+    }
+
+    /**
+     * Decodes a response body bytes into an object.
+     *
+     * @param {Response["prophetData"]["response"]} response - The response body bytes.
+     * @returns {Response["decodedData"]["response"]} Decoded response body object.
+     */
+    static decodeResponse(
+        response: Response["prophetData"]["response"],
+    ): Response["decodedData"]["response"] {
+        const decodedParameters = decodeAbiParameters(RESPONSE_RESPONSE_ABI_FIELDS, response);
+
+        return {
+            block: decodedParameters[0],
+        };
+    }
+}

--- a/packages/automated-dispute/src/services/prophetCodec.ts
+++ b/packages/automated-dispute/src/services/prophetCodec.ts
@@ -3,14 +3,14 @@ import { Address, decodeAbiParameters, encodeAbiParameters } from "viem";
 
 import { Request, Response } from "../types/prophet.js";
 
-const REQUEST_REQUEST_MODULE_DATA_ABI_FIELDS = [
+const REQUEST_MODULE_DATA_REQUEST_ABI_FIELDS = [
     { name: "epoch", type: "uint256" },
     { name: "chainId", type: "string" },
     { name: "accountingExtension", type: "address" },
     { name: "paymentAmount", type: "uint256" },
 ] as const;
 
-const REQUEST_RESPONSE_MODULE_DATA_ABI_FIELDS = [
+const RESPONSE_MODULE_DATA_REQUEST_ABI_FIELDS = [
     { name: "accountingExtension", type: "address" },
     { name: "bondToken", type: "address" },
     { name: "bondSize", type: "uint256" },
@@ -18,7 +18,7 @@ const REQUEST_RESPONSE_MODULE_DATA_ABI_FIELDS = [
     { name: "disputeWindow", type: "uint256" },
 ] as const;
 
-const REQUEST_DISPUTE_MODULE_DATA_ABI_FIELDS = [
+const DISPUTE_MODULE_DATA_REQUEST_ABI_FIELDS = [
     { name: "accountingExtension", type: "address" },
     { name: "bondToken", type: "address" },
     { name: "bondSize", type: "uint256" },
@@ -42,7 +42,7 @@ export class ProphetCodec {
         requestModuleData: Request["prophetData"]["requestModuleData"],
     ): Request["decodedData"]["requestModuleData"] {
         const decodeParameters = decodeAbiParameters(
-            REQUEST_REQUEST_MODULE_DATA_ABI_FIELDS,
+            REQUEST_MODULE_DATA_REQUEST_ABI_FIELDS,
             requestModuleData,
         );
 
@@ -64,7 +64,7 @@ export class ProphetCodec {
     static encodeRequestRequestModuleData(
         requestModuleData: Request["decodedData"]["requestModuleData"],
     ): Request["prophetData"]["requestModuleData"] {
-        return encodeAbiParameters(REQUEST_REQUEST_MODULE_DATA_ABI_FIELDS, [
+        return encodeAbiParameters(REQUEST_MODULE_DATA_REQUEST_ABI_FIELDS, [
             requestModuleData.epoch,
             requestModuleData.chainId,
             requestModuleData.accountingExtension,
@@ -82,7 +82,7 @@ export class ProphetCodec {
         responseModuleData: Request["prophetData"]["responseModuleData"],
     ): Request["decodedData"]["responseModuleData"] {
         const decodedParameters = decodeAbiParameters(
-            REQUEST_RESPONSE_MODULE_DATA_ABI_FIELDS,
+            RESPONSE_MODULE_DATA_REQUEST_ABI_FIELDS,
             responseModuleData,
         );
 
@@ -104,7 +104,7 @@ export class ProphetCodec {
     static encodeRequestResponseModuleData(
         responseModuleData: Request["decodedData"]["responseModuleData"],
     ): Request["prophetData"]["responseModuleData"] {
-        return encodeAbiParameters(REQUEST_RESPONSE_MODULE_DATA_ABI_FIELDS, [
+        return encodeAbiParameters(RESPONSE_MODULE_DATA_REQUEST_ABI_FIELDS, [
             responseModuleData.accountingExtension,
             responseModuleData.bondToken,
             responseModuleData.bondSize,
@@ -123,7 +123,7 @@ export class ProphetCodec {
         disputeModuleData: Request["prophetData"]["disputeModuleData"],
     ): Request["decodedData"]["disputeModuleData"] {
         const decodedParameters = decodeAbiParameters(
-            REQUEST_DISPUTE_MODULE_DATA_ABI_FIELDS,
+            DISPUTE_MODULE_DATA_REQUEST_ABI_FIELDS,
             disputeModuleData,
         );
 
@@ -147,7 +147,7 @@ export class ProphetCodec {
     static encodeRequestDisputeModuleData(
         disputeModuleData: Request["decodedData"]["disputeModuleData"],
     ): Request["prophetData"]["disputeModuleData"] {
-        return encodeAbiParameters(REQUEST_DISPUTE_MODULE_DATA_ABI_FIELDS, [
+        return encodeAbiParameters(DISPUTE_MODULE_DATA_REQUEST_ABI_FIELDS, [
             disputeModuleData.accountingExtension,
             disputeModuleData.bondToken,
             disputeModuleData.bondSize,

--- a/packages/automated-dispute/src/services/prophetCodec.ts
+++ b/packages/automated-dispute/src/services/prophetCodec.ts
@@ -1,11 +1,5 @@
 import { Caip2ChainId } from "@ebo-agent/shared";
-import {
-    Address,
-    decodeAbiParameters,
-    DecodeAbiParametersErrorType,
-    encodeAbiParameters,
-    EncodeAbiParametersErrorType,
-} from "viem";
+import { Address, decodeAbiParameters, encodeAbiParameters } from "viem";
 
 import { Request, Response } from "../types/prophet.js";
 

--- a/packages/automated-dispute/src/services/prophetCodec.ts
+++ b/packages/automated-dispute/src/services/prophetCodec.ts
@@ -1,5 +1,11 @@
 import { Caip2ChainId } from "@ebo-agent/shared";
-import { Address, decodeAbiParameters, encodeAbiParameters } from "viem";
+import {
+    Address,
+    decodeAbiParameters,
+    DecodeAbiParametersErrorType,
+    encodeAbiParameters,
+    EncodeAbiParametersErrorType,
+} from "viem";
 
 import { Request, Response } from "../types/prophet.js";
 
@@ -36,6 +42,7 @@ export class ProphetCodec {
      * Decodes the request's request module data bytes into an object.
      *
      * @param {Request["prophetData"]["requestModuleData"]} requestModuleData - The request module data bytes.
+     * @throws {DecodeAbiParametersErrorType}
      * @returns {Request["decodedData"]["requestModuleData"]} A decoded object with requestModuleData properties.
      */
     static decodeRequestRequestModuleData(
@@ -58,6 +65,7 @@ export class ProphetCodec {
      * Encodes the request's request module data object into bytes.
      *
      * @param {Request["decodedData"]["requestModuleData"]} requestModuleData - The request's request module data object
+     * @throws {EncodeAbiParametersErrorType}
      * @returns {Request["prophetData"]["requestModuleData"]} A byte-encoded request module data object
      */
 
@@ -76,6 +84,7 @@ export class ProphetCodec {
      * Decodes the request's response module data bytes into an object.
      *
      * @param {Request["prophetData"]["responseModuleData"]} responseModuleData - The response module data bytes.
+     * @throws {DecodeAbiParametersErrorType}
      * @returns {Request["decodedData"]["responseModuleData"]} A decoded object with responseModuleData properties.
      */
     static decodeRequestResponseModuleData(
@@ -99,6 +108,7 @@ export class ProphetCodec {
      * Encodes the request's response module data object into bytes.
      *
      * @param {Request["decodedData"]["responseModuleData"]} responseModuleData - The request's response module data object
+     * @throws {EncodeAbiParametersErrorType}
      * @returns {Request["prophetData"]["responseModuleData"]} A byte-encoded response module data object
      */
     static encodeRequestResponseModuleData(
@@ -117,6 +127,7 @@ export class ProphetCodec {
      * Decodes the request's dispute module data bytes into an object.
      *
      * @param {Request["prophetData"]["disputeModuleData"]} disputeModuleData - The dispute module data bytes.
+     * @throws {DecodeAbiParametersErrorType}
      * @returns {Request["decodedData"]["disputeModuleData"]} A decoded object with disputeModuleData properties.
      */
     static decodeRequestDisputeModuleData(
@@ -142,6 +153,7 @@ export class ProphetCodec {
      * Encodes the request's dispute module data object into bytes.
      *
      * @param {Request["decodedData"]["disputeModuleData"]} disputeModuleData - The request's dispute module data object
+     * @throws {EncodeAbiParametersErrorType}
      * @returns {Request["prophetData"]["disputeModuleData"]} A byte-encoded dispute module data object
      */
     static encodeRequestDisputeModuleData(
@@ -162,6 +174,7 @@ export class ProphetCodec {
      * Encodes a response object into bytes.
      *
      * @param {Response["decodedData"]["response"]} response - The response object to encode.
+     * @throws {EncodeAbiParametersErrorType}
      * @returns {Response["prophetData"]["response"]} Byte-encoded response body.
      */
     static encodeResponse(
@@ -174,6 +187,7 @@ export class ProphetCodec {
      * Decodes a response body bytes into an object.
      *
      * @param {Response["prophetData"]["response"]} response - The response body bytes.
+     * @throws {DecodeAbiParametersErrorType}
      * @returns {Response["decodedData"]["response"]} Decoded response body object.
      */
     static decodeResponse(

--- a/packages/automated-dispute/src/types/events.ts
+++ b/packages/automated-dispute/src/types/events.ts
@@ -20,10 +20,9 @@ export type EboEventName =
     | "OracleRequestFinalized";
 
 export interface RequestCreated {
-    epoch: bigint;
-    chainId: Hex; // keccak256 CAIP-2 chain ID
     requestId: RequestId;
     request: Request["prophetData"];
+    ipfsHash: Hex;
 }
 
 export interface ResponseProposed {

--- a/packages/automated-dispute/src/types/prophet.ts
+++ b/packages/automated-dispute/src/types/prophet.ts
@@ -9,17 +9,22 @@ export type RequestStatus = "Active" | "Finalized";
 
 export interface Request {
     id: RequestId;
-    chainId: Caip2ChainId;
-    epoch: bigint;
+    status: RequestStatus;
+
     createdAt: {
         /** Timestamp of the block the request was created on */
         timestamp: UnixTimestamp;
         blockNumber: bigint;
         logIndex: number;
     };
-    status: RequestStatus;
 
     decodedData: {
+        requestModuleData: {
+            epoch: bigint;
+            chainId: Caip2ChainId;
+            accountingExtension: Address;
+            paymentAmount: bigint;
+        };
         responseModuleData: {
             accountingExtension: Address;
             bondToken: Address;
@@ -62,6 +67,7 @@ export type ResponseBody = {
 
 export interface Response {
     id: ResponseId;
+
     createdAt: {
         /** Timestamp of the block the response was created on */
         timestamp: UnixTimestamp;

--- a/packages/automated-dispute/tests/mocks/eboProcessor.mocks.ts
+++ b/packages/automated-dispute/tests/mocks/eboProcessor.mocks.ts
@@ -81,5 +81,6 @@ export function buildEboProcessor(
         blockNumberService,
         actorsManager,
         logger,
+        notifier,
     };
 }

--- a/packages/automated-dispute/tests/services/eboActor.spec.ts
+++ b/packages/automated-dispute/tests/services/eboActor.spec.ts
@@ -1,5 +1,5 @@
 import { UnixTimestamp } from "@ebo-agent/shared";
-import { Abi, ContractFunctionRevertedError, encodeErrorResult, keccak256, toHex } from "viem";
+import { Abi, ContractFunctionRevertedError, encodeErrorResult, Hex } from "viem";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -8,7 +8,6 @@ import {
     PastEventEnqueueError,
     RequestMismatch,
 } from "../../src/exceptions/index.js";
-import { ProtocolProvider } from "../../src/providers/index.js";
 import { EboEvent, Request, RequestId, ResponseId } from "../../src/types/index.js";
 import mocks from "../mocks/index.js";
 import { DEFAULT_MOCKED_REQUEST_CREATED_DATA } from "../services/eboActor/fixtures.js";
@@ -25,22 +24,11 @@ describe("EboActor", () => {
         timestamp: BigInt(Date.UTC(2024, 0, 1, 0, 0, 0) / 1000) as UnixTimestamp,
         requestId: request.id,
         metadata: {
-            chainId: keccak256(toHex(request.chainId)),
-            epoch: request.epoch,
             requestId: request.id,
             request: request.prophetData,
+            ipfsHash: "0x01" as Hex,
         },
     };
-
-    beforeEach(() => {
-        vi.spyOn(ProtocolProvider, "decodeRequestDisputeModuleData").mockReturnValue(
-            request.decodedData.disputeModuleData,
-        );
-
-        vi.spyOn(ProtocolProvider, "decodeRequestResponseModuleData").mockReturnValue(
-            request.decodedData.responseModuleData,
-        );
-    });
 
     afterEach(() => {
         vi.restoreAllMocks();
@@ -452,10 +440,9 @@ describe("EboActor", () => {
                 timestamp: BigInt(Date.UTC(2024, 0, 1, 0, 0, 0) / 1000) as UnixTimestamp,
                 requestId: request.id,
                 metadata: {
-                    chainId: keccak256(toHex(request.chainId)),
-                    epoch: request.epoch,
                     requestId: request.id,
                     request: request.prophetData,
+                    ipfsHash: "0x01" as Hex,
                 },
             };
 

--- a/packages/automated-dispute/tests/services/eboActor/fixtures.ts
+++ b/packages/automated-dispute/tests/services/eboActor/fixtures.ts
@@ -1,7 +1,8 @@
-import { UnixTimestamp } from "@ebo-agent/shared";
+import { Caip2ChainId, UnixTimestamp } from "@ebo-agent/shared";
 import { Address, Hex } from "viem";
 
 import { ProtocolContractsAddresses } from "../../../src/interfaces/index.js";
+import { ProphetCodec } from "../../../src/services/prophetCodec.js";
 import {
     Dispute,
     DisputeId,
@@ -41,10 +42,33 @@ export const DEFAULT_MOCKED_RESPONSE_DATA: Response = {
     },
 };
 
+const DEFAULT_REQUEST_MODULES_DATA = {
+    request: {
+        chainId: "eip155:1" as Caip2ChainId,
+        epoch: 1n,
+        accountingExtension: "0x1234567890123456789012345678901234567890" as Address,
+        paymentAmount: 1n,
+    },
+    response: {
+        accountingExtension: "0x1234567890123456789012345678901234567890" as Address,
+        bondToken: "0x1234567890123456789012345678901234567890" as Address,
+        bondSize: 1n,
+        deadline: 10n,
+        disputeWindow: 1n,
+    },
+    dispute: {
+        accountingExtension: "0x1234567890123456789012345678901234567890" as Address,
+        bondToken: "0x1234567890123456789012345678901234567890" as Address,
+        bondEscalationDeadline: 5n,
+        bondSize: 1n,
+        disputeWindow: 1n,
+        maxNumberOfEscalations: 5n,
+        tyingBuffer: 1n,
+    },
+};
+
 export const DEFAULT_MOCKED_REQUEST_CREATED_DATA: Request = {
     id: "0x01" as RequestId,
-    chainId: "eip155:1",
-    epoch: 1n,
     createdAt: {
         timestamp: BigInt(Date.UTC(2024, 0, 1, 0, 0, 0, 0) / 1000) as UnixTimestamp,
         blockNumber: 1n,
@@ -52,22 +76,9 @@ export const DEFAULT_MOCKED_REQUEST_CREATED_DATA: Request = {
     },
     status: "Active",
     decodedData: {
-        responseModuleData: {
-            accountingExtension: "0x01" as Address,
-            bondToken: "0x02" as Address,
-            bondSize: 1n,
-            deadline: 10n,
-            disputeWindow: 1n,
-        },
-        disputeModuleData: {
-            accountingExtension: "0x01" as Address,
-            bondToken: "0x01" as Address,
-            bondEscalationDeadline: 5n,
-            bondSize: 1n,
-            disputeWindow: 1n,
-            maxNumberOfEscalations: 5n,
-            tyingBuffer: 1n,
-        },
+        requestModuleData: DEFAULT_REQUEST_MODULES_DATA["request"],
+        responseModuleData: DEFAULT_REQUEST_MODULES_DATA["response"],
+        disputeModuleData: DEFAULT_REQUEST_MODULES_DATA["dispute"],
     },
     prophetData: {
         nonce: 1n,
@@ -77,10 +88,16 @@ export const DEFAULT_MOCKED_REQUEST_CREATED_DATA: Request = {
         resolutionModule: "0x0411111111111111111111111111111111111111" as Address,
         responseModule: "0x0511111111111111111111111111111111111111" as Address,
         requester: "0x1011111111111111111111111111111111111111" as Address,
-        responseModuleData: "0x1111111111111111111111111111111111111111" as Hex, // TODO: use the corresponding encoded data
-        disputeModuleData: "0x1211111111111111111111111111111111111111" as Hex, // TODO: use the corresponding encoded data
+        requestModuleData: ProphetCodec.encodeRequestRequestModuleData(
+            DEFAULT_REQUEST_MODULES_DATA["request"],
+        ),
+        responseModuleData: ProphetCodec.encodeRequestResponseModuleData(
+            DEFAULT_REQUEST_MODULES_DATA["response"],
+        ),
+        disputeModuleData: ProphetCodec.encodeRequestDisputeModuleData(
+            DEFAULT_REQUEST_MODULES_DATA["dispute"],
+        ),
         finalityModuleData: "0x1311111111111111111111111111111111111111" as Hex,
-        requestModuleData: "0x1411111111111111111111111111111111111111" as Hex,
         resolutionModuleData: "0x1511111111111111111111111111111111111111" as Hex,
     },
 };

--- a/packages/automated-dispute/tests/services/eboActor/onDisputeStatusUpdated.spec.ts
+++ b/packages/automated-dispute/tests/services/eboActor/onDisputeStatusUpdated.spec.ts
@@ -1,7 +1,7 @@
-import { ILogger } from "@ebo-agent/shared";
+import { ILogger, UnixTimestamp } from "@ebo-agent/shared";
 import { describe, expect, it, vi } from "vitest";
 
-import { ProtocolProvider } from "../../../src/providers/index.ts";
+import { ProphetCodec } from "../../../src/services/prophetCodec.ts";
 import { DisputeId, EboEvent } from "../../../src/types/index.js";
 import mocks from "../../mocks/index.ts";
 import { DEFAULT_MOCKED_REQUEST_CREATED_DATA } from "./fixtures.ts";
@@ -71,9 +71,9 @@ describe("onDisputeStatusUpdated", () => {
         vi.spyOn(registry, "getDispute").mockReturnValue(dispute);
 
         vi.spyOn(protocolProvider, "getCurrentEpoch").mockResolvedValue({
-            number: actorRequest.epoch,
-            firstBlockNumber: actorRequest.createdAt,
-            startTimestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0)),
+            number: actorRequest.decodedData.requestModuleData.epoch,
+            firstBlockNumber: actorRequest.createdAt.blockNumber,
+            startTimestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0)) as UnixTimestamp,
         });
 
         vi.spyOn(blockNumberService, "getEpochBlockNumber").mockResolvedValue(
@@ -93,10 +93,8 @@ describe("onDisputeStatusUpdated", () => {
             expect.objectContaining({
                 proposer: proposerAddress,
                 requestId: actorRequest.id,
-                response: ProtocolProvider.encodeResponse({
+                response: ProphetCodec.encodeResponse({
                     block: 2n,
-                    chainId: actorRequest.chainId,
-                    epoch: actorRequest.epoch,
                 }),
             }),
         );

--- a/packages/automated-dispute/tests/services/eboActor/onResponseProposed.spec.ts
+++ b/packages/automated-dispute/tests/services/eboActor/onResponseProposed.spec.ts
@@ -1,11 +1,11 @@
-import { ILogger } from "@ebo-agent/shared";
+import { ILogger, UnixTimestamp } from "@ebo-agent/shared";
 import { ContractFunctionRevertedError } from "viem";
 import { describe, expect, it, vi } from "vitest";
 
 import { ErrorHandler } from "../../../src/exceptions/errorHandler.js";
 import { ErrorFactory } from "../../../src/exceptions/index.js";
-import { ProtocolProvider } from "../../../src/providers/index.js";
-import { EboEvent, ResponseBody } from "../../../src/types/index.js";
+import { ProphetCodec } from "../../../src/services/prophetCodec.js";
+import { EboEvent, ResponseBody, ResponseId } from "../../../src/types/index.js";
 import mocks from "../../mocks/index.js";
 import { DEFAULT_MOCKED_REQUEST_CREATED_DATA } from "./fixtures.js";
 
@@ -29,11 +29,11 @@ describe("EboActor", () => {
                 logIndex: 2,
                 metadata: {
                     requestId: actorRequest.id,
-                    responseId: "0x02",
+                    responseId: "0x02" as ResponseId,
                     response: {
                         proposer: "0x0000000000000000000000000000000000000003",
                         requestId: actorRequest.id,
-                        response: ProtocolProvider.encodeResponse(proposedResponseBody),
+                        response: ProphetCodec.encodeResponse(proposedResponseBody),
                     },
                 },
             };
@@ -49,7 +49,7 @@ describe("EboActor", () => {
                 vi.spyOn(protocolProvider, "getCurrentEpoch").mockResolvedValue({
                     number: 1n,
                     firstBlockNumber: 1n,
-                    startTimestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)),
+                    startTimestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as UnixTimestamp,
                 });
 
                 vi.spyOn(blockNumberService, "getEpochBlockNumber").mockResolvedValue(
@@ -125,7 +125,7 @@ describe("EboActor", () => {
                 vi.spyOn(protocolProvider, "getCurrentEpoch").mockResolvedValue({
                     number: 1n,
                     firstBlockNumber: 1n,
-                    startTimestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)),
+                    startTimestamp: BigInt(Date.UTC(2024, 1, 1, 0, 0, 0, 0)) as UnixTimestamp,
                 });
 
                 actor.enqueue(responseProposedEvent);

--- a/packages/automated-dispute/tests/services/eboActorsManager.spec.ts
+++ b/packages/automated-dispute/tests/services/eboActorsManager.spec.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { RequestAlreadyHandled } from "../../src/exceptions/index.js";
 import { ProtocolProvider } from "../../src/providers/index.js";
 import { EboActorsManager, NotificationService } from "../../src/services/index.js";
+import { RequestId } from "../../src/types/prophet.js";
 import mocks from "../mocks/index.js";
 import {
     DEFAULT_MOCKED_PROTOCOL_CONTRACTS,
@@ -16,11 +17,13 @@ const logger: ILogger = mocks.mockLogger();
 
 describe("EboActorsManager", () => {
     const request = DEFAULT_MOCKED_REQUEST_CREATED_DATA;
+    const { chainId, epoch } = request.decodedData.requestModuleData;
+
     const actorRequest = {
         id: request.id,
-        epoch: request.epoch,
+        chainId,
+        epoch,
     };
-    const chainId = request.chainId;
 
     let protocolProvider: ProtocolProvider;
     let blockNumberService: BlockNumberService;
@@ -83,7 +86,7 @@ describe("EboActorsManager", () => {
             expect(actor).toMatchObject({
                 actorRequest: expect.objectContaining({
                     id: request.id,
-                    epoch: request.epoch,
+                    epoch: epoch,
                 }),
             });
         });
@@ -133,7 +136,7 @@ describe("EboActorsManager", () => {
         it("returns undefined if the request is not linked to any actor", () => {
             const actorsManager = new EboActorsManager();
 
-            expect(actorsManager.getActor("0x9999")).toBeUndefined();
+            expect(actorsManager.getActor("0x9999" as RequestId)).toBeUndefined();
         });
 
         it("returns the request's linked actor", () => {
@@ -152,7 +155,7 @@ describe("EboActorsManager", () => {
             expect(actor).toMatchObject({
                 actorRequest: expect.objectContaining({
                     id: request.id,
-                    epoch: request.epoch,
+                    epoch: epoch,
                 }),
             });
         });

--- a/packages/automated-dispute/tests/services/prophetCodec.spec.ts
+++ b/packages/automated-dispute/tests/services/prophetCodec.spec.ts
@@ -1,0 +1,35 @@
+import { isHex } from "viem";
+import { describe, expect, it } from "vitest";
+
+import { ProphetCodec } from "../../src/services";
+import { Response } from "../../src/types";
+
+describe("ProphetCodec", () => {
+    describe("encodeResponse", () => {
+        const response: Response["decodedData"]["response"] = {
+            block: 1n,
+        };
+
+        it("generates a hex string with the response encoded", () => {
+            const encodedResponse = ProphetCodec.encodeResponse(response);
+
+            expect(encodedResponse).toSatisfy((bytes) => isHex(bytes));
+        });
+
+        it("is able to decode encoded data correctly", () => {
+            const encodedResponse = ProphetCodec.encodeResponse(response);
+            const decodedResponse = ProphetCodec.decodeResponse(encodedResponse);
+
+            expect(decodedResponse).toEqual(response);
+        });
+    });
+
+    describe.todo("decodeResponse");
+
+    describe.todo("decodeRequestRequestModuleData");
+    describe.todo("encodeRequestRequestModuleData");
+    describe.todo("decodeRequestResponseModuleData");
+    describe.todo("encodeRequestResponseModuleData");
+    describe.todo("decodeRequestDisputeModuleData");
+    describe.todo("encodeRequestDisputeModuleData");
+});

--- a/packages/shared/src/services/caip2Utils.ts
+++ b/packages/shared/src/services/caip2Utils.ts
@@ -68,6 +68,10 @@ export class Caip2Utils {
         return namespace;
     }
 
+    public static isSupported(chainId: Caip2ChainId) {
+        return EBO_SUPPORTED_CHAIN_IDS.includes(chainId);
+    }
+
     /**
      * Fetches the raw chain ID with its keccak256 hash.
      *


### PR DESCRIPTION
# 🤖 Linear

Closes GRT-223

## Description
* Watch `Oracle`'s `RequestCreated` event instead of `EBORequestCreator`'s event.
* Moved decode/encode prophet structs functions into their own class